### PR TITLE
Deribit /private/get_margins in issue #187

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+﻿# Agent Implementation Reference
+
+This project uses dedicated instruction files in the [`.github/instructions`](.github/instructions/) directory to document agent behaviors, code style, testing, and implementation details for different concerns and modules.
+
+Refer to the appropriate guide below depending on your area of development:
+
+## Instruction Files
+
+- [General Coding Guidelines](.github/instructions/general-coding.instructions.md)
+- [REST API Guidelines](.github/instructions/rest.instructions.md)
+- [WebSocket Guidelines](.github/instructions/websocket.instructions.md)
+- [Testing Policy](.github/instructions/testing.instructions.md)
+- [Rate Limiting](.github/instructions/rate-limiting.instructions.md)
+- [Credentials & Secrets](.github/instructions/credentials.instructions.md)
+- [Venue Abstraction](.github/instructions/venue.instructions.md)
+- [Enums](.github/instructions/enums.instructions.md)
+- [Error Handling](.github/instructions/error-handling.instructions.md)
+- [Examples & Recipes](.github/instructions/examples.instructions.md)
+
+---
+
+For further information and module-specific instructions, check the relevant markdown file in [`.github/instructions`](.github/instructions/).

--- a/venues/src/deribit/private/rest/client.rs
+++ b/venues/src/deribit/private/rest/client.rs
@@ -135,6 +135,8 @@ impl RestClient {
         Ok(result)
     }
 
+    // See venues/src/deribit/private/rest/get_margins.rs for get_margins implementation
+
     /// Retrieves initial margins of given orders
     pub async fn get_order_margin_by_ids(&self, ids: Vec<String>) -> RestResult<super::get_order_margin_by_ids::GetOrderMarginByIdsResponse> {
         use super::get_order_margin_by_ids::GetOrderMarginByIdsRequest;

--- a/venues/src/deribit/private/rest/get_margins.rs
+++ b/venues/src/deribit/private/rest/get_margins.rs
@@ -1,0 +1,116 @@
+
+//! Implements the /private/get_margins endpoint for Deribit's REST API.
+//!
+//! Fetches margin requirements for a given instrument, amount, and price.
+//!
+//! Endpoint: /private/get_margins
+//! [Official Deribit Docs](https://docs.deribit.com/v2/#private-get_margins)
+
+use serde::{Deserialize, Serialize};
+use crate::deribit::{RestResult, EndpointType};
+
+/// Request parameters for the `/private/get_margins` endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetMarginsRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Order size requested. For perpetual/inverse futures, this is in USD units; for options and linear futures, the base currency coin.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+
+    /// Price at which to calculate margin.
+    #[serde(rename = "price")]
+    pub price: f64,
+}
+
+/// Margin requirements returned by `/private/get_margins`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetMarginsResult {
+    /// Margin required to open a buy (long) position at this price and size.
+    #[serde(rename = "buy")]
+    pub buy: f64,
+
+    /// Maximum allowed order price for a future. Orders above this are clamped to this max.
+    #[serde(rename = "max_price")]
+    pub max_price: f64,
+
+    /// Minimum allowed order price for a future. Orders below this are clamped to this min.
+    #[serde(rename = "min_price")]
+    pub min_price: f64,
+
+    /// Margin required to open a sell (short) position at this price and size.
+    #[serde(rename = "sell")]
+    pub sell: f64,
+}
+
+/// JSON-RPC standard response structure for `/private/get_margins`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GetMarginsResponse {
+    /// The JSON-RPC version (always "2.0").
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The numeric id returned to match requests.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// Margin calculation result for the given parameters.
+    #[serde(rename = "result")]
+    pub result: GetMarginsResult,
+}
+
+/// Implementation for calling the endpoint from the REST client.
+impl super::client::RestClient {
+    /// Fetches margin requirements for a given instrument, amount, and price.
+    ///
+    /// [Official Deribit Docs](https://docs.deribit.com/v2/#private-get_margins)
+    pub async fn get_margins(&self, params: GetMarginsRequest) -> RestResult<GetMarginsResponse> {
+        self.send_signed_request(
+            "private/get_margins",
+            &params,
+            EndpointType::MatchingEngine,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetMarginsRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            amount: 100.0,
+            price: 25000.0,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("instrument_name"));
+        assert!(json.contains("amount"));
+        assert!(json.contains("price"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"
+        {
+            "jsonrpc": "2.0",
+            "id": 42,
+            "result": {
+                "buy": 10.0,
+                "max_price": 50000.0,
+                "min_price": 21000.0,
+                "sell": 9.0
+            }
+        }
+        "#;
+        let resp: GetMarginsResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 42);
+        assert_eq!(resp.result.buy, 10.0);
+        assert_eq!(resp.result.sell, 9.0);
+    }
+}

--- a/venues/src/deribit/private/rest/mod.rs
+++ b/venues/src/deribit/private/rest/mod.rs
@@ -56,6 +56,7 @@ pub mod submit_transfer_to_subaccount;
 pub mod submit_transfer_to_user;
 pub mod update_in_address_book;
 pub mod withdraw;
+pub mod get_margins;
 
 pub use add_block_rfq_quote::{
     AddBlockRfqQuoteRequest, AddBlockRfqQuoteResponse, AddBlockRfqQuoteResult, BlockRfqHedge, BlockRfqLeg, ExecutionInstruction, ResponseHedge, ResponseLeg,
@@ -128,3 +129,4 @@ pub use submit_transfer_to_subaccount::{SubaccountTransferData, SubmitTransferTo
 pub use submit_transfer_to_user::{SubmitTransferToUserRequest, SubmitTransferToUserResponse, TransferData};
 pub use update_in_address_book::{UpdateInAddressBookRequest, UpdateInAddressBookResponse};
 pub use withdraw::{WithdrawRequest, WithdrawResponse, WithdrawalData};
+pub use get_margins::{GetMarginsRequest, GetMarginsResponse, GetMarginsResult};


### PR DESCRIPTION
This pull request introduces documentation updates and new functionality for the Deribit REST API integration. The most significant changes include the addition of a new endpoint implementation for fetching margin requirements (`get_margins`), updates to the module structure to integrate this endpoint, and the creation of a reference guide for agent implementation.

### New functionality for Deribit REST API:

* Added the `/private/get_margins` endpoint implementation in `venues/src/deribit/private/rest/get_margins.rs` to fetch margin requirements based on instrument, amount, and price. Includes request/response structures, endpoint logic, and unit tests.
* Updated the `RestClient` in `venues/src/deribit/private/rest/client.rs` with a reference to the `get_margins` implementation.

### Module structure updates:

* Added `pub mod get_margins` to `venues/src/deribit/private/rest/mod.rs` to include the new endpoint module.
* Updated `pub use` statements in `venues/src/deribit/private/rest/mod.rs` to export `GetMarginsRequest`, `GetMarginsResponse`, and `GetMarginsResult`.

### Documentation improvements:

* Created `AGENTS.md` as a comprehensive reference for agent implementation, including links to instruction files for coding guidelines, REST API usage, testing policies, and more.