### PR TITLE
fixes to deribit public marketdata

### DIFF
--- a/venues/src/deribit/public/rest/client.rs
+++ b/venues/src/deribit/public/rest/client.rs
@@ -162,7 +162,7 @@ mod tests {
         // Test that rate limiting works (this shouldn't fail since we're not actually hitting limits)
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::NonMatchingEngineGetComboIds)
+            .check_limits(EndpointType::NonMatchingEngine)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/client.rs
+++ b/venues/src/deribit/public/rest/client.rs
@@ -162,7 +162,7 @@ mod tests {
         // Test that rate limiting works (this shouldn't fail since we're not actually hitting limits)
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::PublicGetComboIds)
+            .check_limits(EndpointType::NonMatchingEngineGetComboIds)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_apr_history.rs
+++ b/venues/src/deribit/public/rest/get_apr_history.rs
@@ -2,13 +2,15 @@
 //!
 //! Retrieves historical APR data for specified currency. Only applicable to yield-generating tokens (`USDE`, `STETH`).
 
+use super::RestClient;
 use crate::deribit::enums::Currency;
-use crate::deribit::errors::Result as DeribitResult;
-use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_apr_history endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetAprHistoryRequest {
     /// Currency for which to retrieve APR history. Only `USDE` and `STETH` are supported.
     #[serde(rename = "currency")]
@@ -69,8 +71,14 @@ impl RestClient {
     /// Retrieves historical APR data for specified currency. Only applicable to yield-generating tokens (`USDE`, `STETH`).
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_apr_history)
-    pub async fn get_apr_history(&self, params: GetAprHistoryRequest) -> DeribitResult<GetAprHistoryResponse> {
-        self.call_public("get_apr_history", &params).await
+    pub async fn get_apr_history(&self, params: GetAprHistoryRequest) -> RestResult<GetAprHistoryResponse> {
+        self.send_request(
+            "get_apr_history",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_apr_history.rs
+++ b/venues/src/deribit/public/rest/get_apr_history.rs
@@ -1,0 +1,116 @@
+//! Implements the /public/get_apr_history endpoint for Deribit.
+//!
+//! Retrieves historical APR data for specified currency. Only applicable to yield-generating tokens (`USDE`, `STETH`).
+
+use crate::deribit::enums::Currency;
+use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::public::rest::client::RestClient;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_apr_history endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetAprHistoryRequest {
+    /// Currency for which to retrieve APR history. Only `USDE` and `STETH` are supported.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Number of days to retrieve (default 365, maximum 365).
+    #[serde(rename = "limit", skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+
+    /// Used to receive APR history before given epoch day.
+    #[serde(rename = "before", skip_serializing_if = "Option::is_none")]
+    pub before: Option<u64>,
+}
+
+/// Represents a single APR history data point.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AprHistoryData {
+    /// The APR of the day.
+    #[serde(rename = "apr")]
+    pub apr: f64,
+
+    /// The full epoch day.
+    #[serde(rename = "day")]
+    pub day: u64,
+}
+
+/// The result object for get_apr_history.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetAprHistoryResult {
+    /// Continuation token for pagination.
+    #[serde(rename = "continuation")]
+    pub continuation: String,
+
+    /// Array of APR history data points.
+    #[serde(rename = "data")]
+    pub data: Vec<AprHistoryData>,
+}
+
+/// Response for the get_apr_history endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetAprHistoryResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing APR history data.
+    #[serde(rename = "result")]
+    pub result: GetAprHistoryResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_apr_history endpoint.
+    ///
+    /// Retrieves historical APR data for specified currency. Only applicable to yield-generating tokens (`USDE`, `STETH`).
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_apr_history)
+    pub async fn get_apr_history(&self, params: GetAprHistoryRequest) -> DeribitResult<GetAprHistoryResponse> {
+        self.call_public("get_apr_history", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetAprHistoryRequest {
+            currency: Currency::USDE,
+            limit: Some(10),
+            before: Some(1234567),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("USDE"));
+        assert!(json.contains("limit"));
+        assert!(json.contains("before"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": {
+                "continuation": "abc123",
+                "data": [
+                    { "apr": 0.045, "day": 19000 },
+                    { "apr": 0.046, "day": 19001 }
+                ]
+            }
+        }"#;
+        let resp: GetAprHistoryResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.continuation, "abc123");
+        assert_eq!(resp.result.data.len(), 2);
+        assert!((resp.result.data[0].apr - 0.045).abs() < 1e-8);
+        assert_eq!(resp.result.data[1].day, 19001);
+    }
+}

--- a/venues/src/deribit/public/rest/get_book_summary_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_book_summary_by_currency.rs
@@ -1,0 +1,201 @@
+//! Implements the /public/get_book_summary_by_currency endpoint for Deribit.
+//!
+//! Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
+
+use crate::deribit::enums::{Currency, InstrumentKind};
+use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::public::rest::client::RestClient;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_book_summary_by_currency endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetBookSummaryByCurrencyRequest {
+    /// The currency symbol.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Instrument kind, if not provided instruments of all kinds are considered.
+    #[serde(rename = "kind", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<InstrumentKind>,
+}
+
+/// Represents a single book summary entry for an instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BookSummary {
+    /// The current best ask price, null if there aren't any asks.
+    #[serde(rename = "ask_price")]
+    pub ask_price: Option<f64>,
+
+    /// Base currency.
+    #[serde(rename = "base_currency")]
+    pub base_currency: Currency,
+
+    /// The current best bid price, null if there aren't any bids.
+    #[serde(rename = "bid_price")]
+    pub bid_price: Option<f64>,
+
+    /// The timestamp (milliseconds since the Unix epoch).
+    #[serde(rename = "creation_timestamp")]
+    pub creation_timestamp: u64,
+
+    /// Current funding (perpetual only).
+    #[serde(rename = "current_funding")]
+    pub current_funding: Option<f64>,
+
+    /// Estimated delivery price for the market (derivatives only).
+    #[serde(rename = "estimated_delivery_price")]
+    pub estimated_delivery_price: Option<f64>,
+
+    /// Funding 8h (perpetual only).
+    #[serde(rename = "funding_8h")]
+    pub funding_8h: Option<f64>,
+
+    /// Price of the 24h highest trade.
+    #[serde(rename = "high")]
+    pub high: Option<f64>,
+
+    /// Unique instrument identifier.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Interest rate used in implied volatility calculations (options only).
+    #[serde(rename = "interest_rate")]
+    pub interest_rate: Option<f64>,
+
+    /// The price of the latest trade, null if there weren't any trades.
+    #[serde(rename = "last")]
+    pub last: Option<f64>,
+
+    /// Price of the 24h lowest trade, null if there weren't any trades.
+    #[serde(rename = "low")]
+    pub low: Option<f64>,
+
+    /// (Only for option) implied volatility for mark price.
+    #[serde(rename = "mark_iv")]
+    pub mark_iv: Option<f64>,
+
+    /// The current instrument market price.
+    #[serde(rename = "mark_price")]
+    pub mark_price: f64,
+
+    /// The average of the best bid and ask, null if there aren't any asks or bids.
+    #[serde(rename = "mid_price")]
+    pub mid_price: Option<f64>,
+
+    /// The total amount of outstanding contracts (derivatives only).
+    #[serde(rename = "open_interest")]
+    pub open_interest: Option<f64>,
+
+    /// 24-hour price change expressed as a percentage, null if there weren't any trades.
+    #[serde(rename = "price_change")]
+    pub price_change: Option<f64>,
+
+    /// Quote currency.
+    #[serde(rename = "quote_currency")]
+    pub quote_currency: Currency,
+
+    /// Name of the underlying future, or 'index_price' (options only).
+    #[serde(rename = "underlying_index")]
+    pub underlying_index: String,
+
+    /// Underlying price for implied volatility calculations (options only).
+    #[serde(rename = "underlying_price")]
+    pub underlying_price: Option<f64>,
+
+    /// The total 24h traded volume (in base currency).
+    #[serde(rename = "volume")]
+    pub volume: f64,
+
+    /// Volume in quote currency (futures and spots only).
+    #[serde(rename = "volume_notional")]
+    pub volume_notional: Option<f64>,
+
+    /// Volume in USD.
+    #[serde(rename = "volume_usd")]
+    pub volume_usd: Option<f64>,
+}
+
+/// Response for the get_book_summary_by_currency endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetBookSummaryByCurrencyResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result array of book summaries.
+    #[serde(rename = "result")]
+    pub result: Vec<BookSummary>,
+}
+
+impl RestClient {
+    /// Calls the /public/get_book_summary_by_currency endpoint.
+    ///
+    /// Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_book_summary_by_currency)
+    pub async fn get_book_summary_by_currency(&self, params: GetBookSummaryByCurrencyRequest) -> DeribitResult<GetBookSummaryByCurrencyResponse> {
+        self.call_public("get_book_summary_by_currency", &params)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetBookSummaryByCurrencyRequest {
+            currency: Currency::BTC,
+            kind: Some(InstrumentKind::Future),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("future"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "ask_price": 100.0,
+                    "base_currency": "BTC",
+                    "bid_price": 99.0,
+                    "creation_timestamp": 1234567890,
+                    "current_funding": 0.01,
+                    "estimated_delivery_price": 101.0,
+                    "funding_8h": 0.02,
+                    "high": 110.0,
+                    "instrument_name": "BTC-PERPETUAL",
+                    "interest_rate": 0.05,
+                    "last": 100.5,
+                    "low": 90.0,
+                    "mark_iv": 0.6,
+                    "mark_price": 100.2,
+                    "mid_price": 99.5,
+                    "open_interest": 10000.0,
+                    "price_change": 0.01,
+                    "quote_currency": "USD",
+                    "underlying_index": "BTC-USD",
+                    "underlying_price": 100.0,
+                    "volume": 500.0,
+                    "volume_notional": 50000.0,
+                    "volume_usd": 50000.0
+                }
+            ]
+        }"#;
+        let resp: GetBookSummaryByCurrencyResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.len(), 1);
+        assert_eq!(resp.result[0].instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_book_summary_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_book_summary_by_currency.rs
@@ -2,13 +2,16 @@
 //!
 //! Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
 
+use super::RestClient;
+use crate::deribit::EndpointType;
+use crate::deribit::RestResult;
 use crate::deribit::enums::{Currency, InstrumentKind};
-use crate::deribit::errors::Result as DeribitResult;
-use crate::deribit::public::rest::client::RestClient;
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_book_summary_by_currency endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetBookSummaryByCurrencyRequest {
     /// The currency symbol.
     #[serde(rename = "currency")]
@@ -137,9 +140,14 @@ impl RestClient {
     /// Retrieves the summary information such as open interest, 24h volume, etc. for all instruments for the currency (optionally filtered by kind).
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_book_summary_by_currency)
-    pub async fn get_book_summary_by_currency(&self, params: GetBookSummaryByCurrencyRequest) -> DeribitResult<GetBookSummaryByCurrencyResponse> {
-        self.call_public("get_book_summary_by_currency", &params)
-            .await
+    pub async fn get_book_summary_by_currency(&self, params: GetBookSummaryByCurrencyRequest) -> RestResult<GetBookSummaryByCurrencyResponse> {
+        self.send_request(
+            "get_book_summary_by_currency",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_book_summary_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_book_summary_by_instrument.rs
@@ -2,9 +2,12 @@
 //!
 //! Retrieves the summary information such as open interest, 24h volume, etc. for a specific instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::{Result as DeribitResult};
-use crate::deribit::enums::{Currency};
+use super::RestClient;
+use crate::deribit::EndpointType;
+use crate::deribit::RestResult;
+use crate::deribit::enums::Currency;
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_book_summary_by_instrument endpoint.
@@ -133,8 +136,14 @@ impl RestClient {
     /// Retrieves the summary information such as open interest, 24h volume, etc. for a specific instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_book_summary_by_instrument)
-    pub async fn get_book_summary_by_instrument(&self, params: GetBookSummaryByInstrumentRequest) -> DeribitResult<GetBookSummaryByInstrumentResponse> {
-        self.call_public("get_book_summary_by_instrument", &params).await
+    pub async fn get_book_summary_by_instrument(&self, params: GetBookSummaryByInstrumentRequest) -> RestResult<GetBookSummaryByInstrumentResponse> {
+        self.send_request(
+            "get_book_summary_by_instrument",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_book_summary_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_book_summary_by_instrument.rs
@@ -1,0 +1,194 @@
+//! Implements the /public/get_book_summary_by_instrument endpoint for Deribit.
+//!
+//! Retrieves the summary information such as open interest, 24h volume, etc. for a specific instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::{Result as DeribitResult};
+use crate::deribit::enums::{Currency};
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_book_summary_by_instrument endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetBookSummaryByInstrumentRequest {
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// Represents a single book summary entry for an instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BookSummaryByInstrument {
+    /// The current best ask price, null if there aren't any asks.
+    #[serde(rename = "ask_price")]
+    pub ask_price: Option<f64>,
+
+    /// Base currency.
+    #[serde(rename = "base_currency")]
+    pub base_currency: Currency,
+
+    /// The current best bid price, null if there aren't any bids.
+    #[serde(rename = "bid_price")]
+    pub bid_price: Option<f64>,
+
+    /// The timestamp (milliseconds since the Unix epoch).
+    #[serde(rename = "creation_timestamp")]
+    pub creation_timestamp: u64,
+
+    /// Current funding (perpetual only).
+    #[serde(rename = "current_funding")]
+    pub current_funding: Option<f64>,
+
+    /// Estimated delivery price for the market (derivatives only).
+    #[serde(rename = "estimated_delivery_price")]
+    pub estimated_delivery_price: Option<f64>,
+
+    /// Funding 8h (perpetual only).
+    #[serde(rename = "funding_8h")]
+    pub funding_8h: Option<f64>,
+
+    /// Price of the 24h highest trade.
+    #[serde(rename = "high")]
+    pub high: Option<f64>,
+
+    /// Unique instrument identifier.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Interest rate used in implied volatility calculations (options only).
+    #[serde(rename = "interest_rate")]
+    pub interest_rate: Option<f64>,
+
+    /// The price of the latest trade, null if there weren't any trades.
+    #[serde(rename = "last")]
+    pub last: Option<f64>,
+
+    /// Price of the 24h lowest trade, null if there weren't any trades.
+    #[serde(rename = "low")]
+    pub low: Option<f64>,
+
+    /// (Only for option) implied volatility for mark price.
+    #[serde(rename = "mark_iv")]
+    pub mark_iv: Option<f64>,
+
+    /// The current instrument market price.
+    #[serde(rename = "mark_price")]
+    pub mark_price: f64,
+
+    /// The average of the best bid and ask, null if there aren't any asks or bids.
+    #[serde(rename = "mid_price")]
+    pub mid_price: Option<f64>,
+
+    /// The total amount of outstanding contracts (derivatives only).
+    #[serde(rename = "open_interest")]
+    pub open_interest: Option<f64>,
+
+    /// 24-hour price change expressed as a percentage, null if there weren't any trades.
+    #[serde(rename = "price_change")]
+    pub price_change: Option<f64>,
+
+    /// Quote currency.
+    #[serde(rename = "quote_currency")]
+    pub quote_currency: Currency,
+
+    /// Name of the underlying future, or 'index_price' (options only).
+    #[serde(rename = "underlying_index")]
+    pub underlying_index: String,
+
+    /// Underlying price for implied volatility calculations (options only).
+    #[serde(rename = "underlying_price")]
+    pub underlying_price: Option<f64>,
+
+    /// The total 24h traded volume (in base currency).
+    #[serde(rename = "volume")]
+    pub volume: f64,
+
+    /// Volume in quote currency (futures and spots only).
+    #[serde(rename = "volume_notional")]
+    pub volume_notional: Option<f64>,
+
+    /// Volume in USD.
+    #[serde(rename = "volume_usd")]
+    pub volume_usd: Option<f64>,
+}
+
+/// Response for the get_book_summary_by_instrument endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetBookSummaryByInstrumentResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result array of book summaries (should be length 1 for a single instrument).
+    #[serde(rename = "result")]
+    pub result: Vec<BookSummaryByInstrument>,
+}
+
+impl RestClient {
+    /// Calls the /public/get_book_summary_by_instrument endpoint.
+    ///
+    /// Retrieves the summary information such as open interest, 24h volume, etc. for a specific instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_book_summary_by_instrument)
+    pub async fn get_book_summary_by_instrument(&self, params: GetBookSummaryByInstrumentRequest) -> DeribitResult<GetBookSummaryByInstrumentResponse> {
+        self.call_public("get_book_summary_by_instrument", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetBookSummaryByInstrumentRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "ask_price": 100.0,
+                    "base_currency": "BTC",
+                    "bid_price": 99.0,
+                    "creation_timestamp": 1234567890,
+                    "current_funding": 0.01,
+                    "estimated_delivery_price": 101.0,
+                    "funding_8h": 0.02,
+                    "high": 110.0,
+                    "instrument_name": "BTC-PERPETUAL",
+                    "interest_rate": 0.05,
+                    "last": 100.5,
+                    "low": 90.0,
+                    "mark_iv": 0.6,
+                    "mark_price": 100.2,
+                    "mid_price": 99.5,
+                    "open_interest": 10000.0,
+                    "price_change": 0.01,
+                    "quote_currency": "USD",
+                    "underlying_index": "BTC-USD",
+                    "underlying_price": 100.0,
+                    "volume": 500.0,
+                    "volume_notional": 50000.0,
+                    "volume_usd": 50000.0
+                }
+            ]
+        }"#;
+        let resp: GetBookSummaryByInstrumentResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.len(), 1);
+        assert_eq!(resp.result[0].instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_combo_details.rs
+++ b/venues/src/deribit/public/rest/get_combo_details.rs
@@ -2,11 +2,11 @@
 //!
 //! Retrieves information about a combo
 
-use serde::{Deserialize, Serialize};
-
 use super::client::RestClient;
 use super::get_combos::ComboInfo;
 use crate::deribit::{EndpointType, RestResult};
+
+use serde::{Deserialize, Serialize};
 
 /// Request parameters for the public/get_combo_details endpoint.
 ///
@@ -47,7 +47,7 @@ impl RestClient {
             "public/get_combo_details",
             reqwest::Method::GET,
             Some(&params),
-            EndpointType::PublicGetComboDetails,
+            EndpointType::NonMatchingEngineGetComboDetails,
         )
         .await
     }
@@ -159,7 +159,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::PublicGetComboDetails)
+            .check_limits(EndpointType::NonMatchingEngineGetComboDetails)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_combo_details.rs
+++ b/venues/src/deribit/public/rest/get_combo_details.rs
@@ -47,7 +47,7 @@ impl RestClient {
             "public/get_combo_details",
             reqwest::Method::GET,
             Some(&params),
-            EndpointType::NonMatchingEngineGetComboDetails,
+            EndpointType::NonMatchingEngine,
         )
         .await
     }
@@ -159,7 +159,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::NonMatchingEngineGetComboDetails)
+            .check_limits(EndpointType::NonMatchingEngine)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_combo_ids.rs
+++ b/venues/src/deribit/public/rest/get_combo_ids.rs
@@ -3,10 +3,10 @@
 //! Retrieves available combos. This method can be used to get the list of all
 //! combos, or only the list of combos in the given state.
 
-use serde::{Deserialize, Serialize};
-
-use super::client::RestClient;
+use super::RestClient;
 use crate::deribit::{ComboState, Currency, EndpointType, RestResult};
+
+use serde::{Deserialize, Serialize};
 
 /// Request parameters for the public/get_combo_ids endpoint.
 ///
@@ -53,7 +53,7 @@ impl RestClient {
             "public/get_combo_ids",
             reqwest::Method::GET,
             Some(&params),
-            EndpointType::PublicGetComboIds,
+            EndpointType::NonMatchingEngineGetComboIds,
         )
         .await
     }
@@ -157,7 +157,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::PublicGetComboIds)
+            .check_limits(EndpointType::NonMatchingEngineGetComboIds)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_combo_ids.rs
+++ b/venues/src/deribit/public/rest/get_combo_ids.rs
@@ -53,7 +53,7 @@ impl RestClient {
             "public/get_combo_ids",
             reqwest::Method::GET,
             Some(&params),
-            EndpointType::NonMatchingEngineGetComboIds,
+            EndpointType::NonMatchingEngine,
         )
         .await
     }
@@ -157,7 +157,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::NonMatchingEngineGetComboIds)
+            .check_limits(EndpointType::NonMatchingEngine)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_combos.rs
+++ b/venues/src/deribit/public/rest/get_combos.rs
@@ -192,7 +192,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::NonMatchingEngineGetCombos)
+            .check_limits(EndpointType::NonMatchingEngine)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_combos.rs
+++ b/venues/src/deribit/public/rest/get_combos.rs
@@ -192,7 +192,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::PublicGetCombos)
+            .check_limits(EndpointType::NonMatchingEngineGetCombos)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_contract_size.rs
+++ b/venues/src/deribit/public/rest/get_contract_size.rs
@@ -2,8 +2,9 @@
 //!
 //! Retrieves contract size of provided instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::{Result as DeribitResult};
+use super::RestClient;
+use crate::deribit::errors::RestResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_contract_size endpoint.
@@ -44,7 +45,7 @@ impl RestClient {
     /// Retrieves contract size of provided instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_contract_size)
-    pub async fn get_contract_size(&self, params: GetContractSizeRequest) -> DeribitResult<GetContractSizeResponse> {
+    pub async fn get_contract_size(&self, params: GetContractSizeRequest) -> RestResult<GetContractSizeResponse> {
         self.call_public("get_contract_size", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_contract_size.rs
+++ b/venues/src/deribit/public/rest/get_contract_size.rs
@@ -3,8 +3,9 @@
 //! Retrieves contract size of provided instrument.
 
 use super::RestClient;
-use crate::deribit::errors::RestResult;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_contract_size endpoint.
@@ -46,7 +47,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_contract_size)
     pub async fn get_contract_size(&self, params: GetContractSizeRequest) -> RestResult<GetContractSizeResponse> {
-        self.call_public("get_contract_size", &params).await
+        self.send_request(
+            "get_contract_size",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_contract_size.rs
+++ b/venues/src/deribit/public/rest/get_contract_size.rs
@@ -1,0 +1,80 @@
+//! Implements the /public/get_contract_size endpoint for Deribit.
+//!
+//! Retrieves contract size of provided instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::{Result as DeribitResult};
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_contract_size endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetContractSizeRequest {
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_contract_size.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetContractSizeResult {
+    /// Contract size, for futures in USD, for options in base currency of the instrument (BTC, ETH, ...).
+    #[serde(rename = "contract_size")]
+    pub contract_size: u64,
+}
+
+/// Response for the get_contract_size endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetContractSizeResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing contract size.
+    #[serde(rename = "result")]
+    pub result: GetContractSizeResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_contract_size endpoint.
+    ///
+    /// Retrieves contract size of provided instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_contract_size)
+    pub async fn get_contract_size(&self, params: GetContractSizeRequest) -> DeribitResult<GetContractSizeResponse> {
+        self.call_public("get_contract_size", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetContractSizeRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": {
+                "contract_size": 100
+            }
+        }"#;
+        let resp: GetContractSizeResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.contract_size, 100);
+    }
+}

--- a/venues/src/deribit/public/rest/get_currencies.rs
+++ b/venues/src/deribit/public/rest/get_currencies.rs
@@ -7,7 +7,7 @@ use crate::deribit::enums::Currency;
 use crate::deribit::{EndpointType, RestResult};
 
 use reqwest::Method;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 /// Represents a withdrawal priority for a currency.
 #[derive(Debug, Clone, Deserialize)]

--- a/venues/src/deribit/public/rest/get_currencies.rs
+++ b/venues/src/deribit/public/rest/get_currencies.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves all cryptocurrencies supported by the API.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::{Result as DeribitResult};
+use super::RestClient;
 use crate::deribit::enums::Currency;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Represents a withdrawal priority for a currency.
@@ -85,8 +87,14 @@ impl RestClient {
     /// Retrieves all cryptocurrencies supported by the API.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_currencies)
-    pub async fn get_currencies(&self) -> DeribitResult<GetCurrenciesResponse> {
-        self.call_public("get_currencies", &()).await
+    pub async fn get_currencies(&self) -> RestResult<GetCurrenciesResponse> {
+        self.send_request(
+            "get_currencies",
+            Method::POST,
+            None::<&()>,
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_currencies.rs
+++ b/venues/src/deribit/public/rest/get_currencies.rs
@@ -1,0 +1,128 @@
+//! Implements the /public/get_currencies endpoint for Deribit.
+//!
+//! Retrieves all cryptocurrencies supported by the API.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::{Result as DeribitResult};
+use crate::deribit::enums::Currency;
+use serde::{Deserialize, Serialize};
+
+/// Represents a withdrawal priority for a currency.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WithdrawalPriority {
+    /// Name of the withdrawal priority.
+    #[serde(rename = "name")]
+    pub name: String,
+
+    /// Value of the withdrawal priority.
+    #[serde(rename = "value")]
+    pub value: f64,
+}
+
+/// Represents a single currency supported by the API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CurrencyInfo {
+    /// Simple Moving Average (SMA) of the last 7 days of rewards. Only for yield-generating tokens.
+    #[serde(rename = "apr")]
+    pub apr: Option<f64>,
+
+    /// The type of the currency.
+    #[serde(rename = "coin_type")]
+    pub coin_type: String,
+
+    /// The abbreviation of the currency.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// The full name for the currency.
+    #[serde(rename = "currency_long")]
+    pub currency_long: String,
+
+    /// Fee precision.
+    #[serde(rename = "fee_precision")]
+    pub fee_precision: u32,
+
+    /// True if the currency is part of the cross collateral pool.
+    #[serde(rename = "in_cross_collateral_pool")]
+    pub in_cross_collateral_pool: bool,
+
+    /// Minimum number of block chain confirmations before deposit is accepted.
+    #[serde(rename = "min_confirmations")]
+    pub min_confirmations: u32,
+
+    /// The minimum transaction fee paid for withdrawals.
+    #[serde(rename = "min_withdrawal_fee")]
+    pub min_withdrawal_fee: f64,
+
+    /// The total transaction fee paid for withdrawals.
+    #[serde(rename = "withdrawal_fee")]
+    pub withdrawal_fee: f64,
+
+    /// Withdrawal priorities for the currency.
+    #[serde(rename = "withdrawal_priorities")]
+    pub withdrawal_priorities: Vec<WithdrawalPriority>,
+}
+
+/// Response for the get_currencies endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetCurrenciesResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result array of supported currencies.
+    #[serde(rename = "result")]
+    pub result: Vec<CurrencyInfo>,
+}
+
+impl RestClient {
+    /// Calls the /public/get_currencies endpoint.
+    ///
+    /// Retrieves all cryptocurrencies supported by the API.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_currencies)
+    pub async fn get_currencies(&self) -> DeribitResult<GetCurrenciesResponse> {
+        self.call_public("get_currencies", &()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": [
+                {
+                    "apr": 0.05,
+                    "coin_type": "crypto",
+                    "currency": "BTC",
+                    "currency_long": "Bitcoin",
+                    "fee_precision": 8,
+                    "in_cross_collateral_pool": true,
+                    "min_confirmations": 2,
+                    "min_withdrawal_fee": 0.0005,
+                    "withdrawal_fee": 0.0007,
+                    "withdrawal_priorities": [
+                        { "name": "high", "value": 0.0007 }
+                    ]
+                }
+            ]
+        }"#;
+        let resp: GetCurrenciesResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.len(), 1);
+        assert_eq!(resp.result[0].currency, Currency::BTC);
+        assert_eq!(resp.result[0].currency_long, "Bitcoin");
+        assert!(resp.result[0].in_cross_collateral_pool);
+    }
+}

--- a/venues/src/deribit/public/rest/get_delivery_prices.rs
+++ b/venues/src/deribit/public/rest/get_delivery_prices.rs
@@ -3,9 +3,10 @@
 //! Retrieves delivery prices for the given index.
 
 use super::RestClient;
-use crate::deribit::RestResult;
 use crate::deribit::enums::CurrencyPair;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_delivery_prices endpoint.
@@ -71,7 +72,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_delivery_prices)
     pub async fn get_delivery_prices(&self, params: GetDeliveryPricesRequest) -> RestResult<GetDeliveryPricesResponse> {
-        self.call_public("get_delivery_prices", &params).await
+        self.send_request(
+            "get_delivery_prices",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_delivery_prices.rs
+++ b/venues/src/deribit/public/rest/get_delivery_prices.rs
@@ -2,13 +2,14 @@
 //!
 //! Retrieves delivery prices for the given index.
 
+use super::RestClient;
+use crate::deribit::RestResult;
 use crate::deribit::enums::CurrencyPair;
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::{Result as DeribitResult};
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_delivery_prices endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetDeliveryPricesRequest {
     /// Index identifier, matches (base) cryptocurrency with quote currency.
     #[serde(rename = "index_name")]
@@ -69,7 +70,7 @@ impl RestClient {
     /// Retrieves delivery prices for the given index.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_delivery_prices)
-    pub async fn get_delivery_prices(&self, params: GetDeliveryPricesRequest) -> DeribitResult<GetDeliveryPricesResponse> {
+    pub async fn get_delivery_prices(&self, params: GetDeliveryPricesRequest) -> RestResult<GetDeliveryPricesResponse> {
         self.call_public("get_delivery_prices", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_delivery_prices.rs
+++ b/venues/src/deribit/public/rest/get_delivery_prices.rs
@@ -1,0 +1,117 @@
+//! Implements the /public/get_delivery_prices endpoint for Deribit.
+//!
+//! Retrieves delivery prices for the given index.
+
+use crate::deribit::enums::CurrencyPair;
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::{Result as DeribitResult};
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_delivery_prices endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetDeliveryPricesRequest {
+    /// Index identifier, matches (base) cryptocurrency with quote currency.
+    #[serde(rename = "index_name")]
+    pub index_name: CurrencyPair,
+
+    /// The offset for pagination, default 0.
+    #[serde(rename = "offset", skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
+
+    /// Number of requested items, default 10.
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}
+
+/// Represents a single delivery price record.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeliveryPriceRecord {
+    /// The event date with year, month and day.
+    #[serde(rename = "date")]
+    pub date: String,
+
+    /// The settlement price for the instrument. Only when state = closed.
+    #[serde(rename = "delivery_price")]
+    pub delivery_price: f64,
+}
+
+/// The result object for get_delivery_prices.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetDeliveryPricesResult {
+    /// Array of delivery price records.
+    #[serde(rename = "data")]
+    pub data: Vec<DeliveryPriceRecord>,
+
+    /// Available delivery prices.
+    #[serde(rename = "records_total")]
+    pub records_total: u32,
+}
+
+/// Response for the get_delivery_prices endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetDeliveryPricesResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing delivery price data.
+    #[serde(rename = "result")]
+    pub result: GetDeliveryPricesResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_delivery_prices endpoint.
+    ///
+    /// Retrieves delivery prices for the given index.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_delivery_prices)
+    pub async fn get_delivery_prices(&self, params: GetDeliveryPricesRequest) -> DeribitResult<GetDeliveryPricesResponse> {
+        self.call_public("get_delivery_prices", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::CurrencyPair;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetDeliveryPricesRequest {
+            index_name: CurrencyPair::BtcUsd,
+            offset: Some(5),
+            count: Some(10),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("btc_usd"));
+        assert!(json.contains("offset"));
+        assert!(json.contains("count"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": {
+                "data": [
+                    { "date": "2024-06-01", "delivery_price": 65000.0 },
+                    { "date": "2024-06-02", "delivery_price": 65500.0 }
+                ],
+                "records_total": 2
+            }
+        }"#;
+        let resp: GetDeliveryPricesResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.data.len(), 2);
+        assert_eq!(resp.result.records_total, 2);
+        assert_eq!(resp.result.data[0].date, "2024-06-01");
+        assert!((resp.result.data[1].delivery_price - 65500.0).abs() < 1e-8);
+    }
+}

--- a/venues/src/deribit/public/rest/get_expirations.rs
+++ b/venues/src/deribit/public/rest/get_expirations.rs
@@ -3,9 +3,10 @@
 //! Retrieves available expiration timestamps for a given currency and instrument kind.
 
 use super::RestClient;
-use crate::deribit::RestResult;
 use crate::deribit::enums::Currency;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Instrument kind for get_expirations endpoint.
@@ -21,7 +22,7 @@ pub enum InstrumentKind {
 }
 
 /// Request parameters for the get_expirations endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetExpirationsRequest {
     /// Currency for which to retrieve expirations.
     #[serde(rename = "currency")]
@@ -63,7 +64,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_expirations)
     pub async fn get_expirations(&self, params: GetExpirationsRequest) -> RestResult<GetExpirationsResponse> {
-        self.call_public("get_expirations", &params).await
+        self.send_request(
+            "get_expirations",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_expirations.rs
+++ b/venues/src/deribit/public/rest/get_expirations.rs
@@ -2,9 +2,10 @@
 //!
 //! Retrieves available expiration timestamps for a given currency and instrument kind.
 
+use super::RestClient;
+use crate::deribit::RestResult;
 use crate::deribit::enums::Currency;
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Instrument kind for get_expirations endpoint.
@@ -61,7 +62,7 @@ impl RestClient {
     /// Retrieves available expiration timestamps for a given currency and instrument kind.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_expirations)
-    pub async fn get_expirations(&self, params: GetExpirationsRequest) -> DeribitResult<GetExpirationsResponse> {
+    pub async fn get_expirations(&self, params: GetExpirationsRequest) -> RestResult<GetExpirationsResponse> {
         self.call_public("get_expirations", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_expirations.rs
+++ b/venues/src/deribit/public/rest/get_expirations.rs
@@ -1,0 +1,100 @@
+//! Implements the /public/get_expirations endpoint for Deribit.
+//!
+//! Retrieves available expiration timestamps for a given currency and instrument kind.
+
+use crate::deribit::enums::Currency;
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Instrument kind for get_expirations endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum InstrumentKind {
+    /// Futures
+    #[serde(rename = "future")]
+    Future,
+    /// Options
+    #[serde(rename = "option")]
+    Option,
+}
+
+/// Request parameters for the get_expirations endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetExpirationsRequest {
+    /// Currency for which to retrieve expirations.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Instrument kind: "future" or "option". Optional.
+    #[serde(rename = "kind", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<InstrumentKind>,
+}
+
+/// The result object for get_expirations.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetExpirationsResult {
+    /// List of available expiration timestamps (milliseconds since epoch).
+    #[serde(rename = "expirations")]
+    pub expirations: Vec<u64>,
+}
+
+/// Response for the get_expirations endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetExpirationsResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing expiration data.
+    #[serde(rename = "result")]
+    pub result: GetExpirationsResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_expirations endpoint.
+    ///
+    /// Retrieves available expiration timestamps for a given currency and instrument kind.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_expirations)
+    pub async fn get_expirations(&self, params: GetExpirationsRequest) -> DeribitResult<GetExpirationsResponse> {
+        self.call_public("get_expirations", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetExpirationsRequest {
+            currency: Currency::BTC,
+            kind: Some(InstrumentKind::Option),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("option"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 42,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"expirations\": [1680307200000, 1682918400000, 1685529600000]
+            }
+        }"#;
+        let resp: GetExpirationsResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 42);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.expirations.len(), 3);
+        assert_eq!(resp.result.expirations[0], 1680307200000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_funding_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_funding_chart_data.rs
@@ -3,8 +3,9 @@
 //! Retrieves funding chart data for a given instrument name.
 
 use super::RestClient;
-use crate::deribit::RestResult;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_funding_chart_data endpoint.
@@ -58,7 +59,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_funding_chart_data)
     pub async fn get_funding_chart_data(&self, params: GetFundingChartDataRequest) -> RestResult<GetFundingChartDataResponse> {
-        self.call_public("get_funding_chart_data", &params).await
+        self.send_request(
+            "get_funding_chart_data",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_funding_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_funding_chart_data.rs
@@ -2,8 +2,9 @@
 //!
 //! Retrieves funding chart data for a given instrument name.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_funding_chart_data endpoint.
@@ -56,7 +57,7 @@ impl RestClient {
     /// Retrieves funding chart data for a given instrument name.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_funding_chart_data)
-    pub async fn get_funding_chart_data(&self, params: GetFundingChartDataRequest) -> DeribitResult<GetFundingChartDataResponse> {
+    pub async fn get_funding_chart_data(&self, params: GetFundingChartDataRequest) -> RestResult<GetFundingChartDataResponse> {
         self.call_public("get_funding_chart_data", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_funding_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_funding_chart_data.rs
@@ -1,0 +1,97 @@
+//! Implements the /public/get_funding_chart_data endpoint for Deribit.
+//!
+//! Retrieves funding chart data for a given instrument name.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_funding_chart_data endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetFundingChartDataRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// Represents a single funding chart data point.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FundingChartDataPoint {
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+
+    /// Funding rate value at this timestamp.
+    #[serde(rename = "funding_rate")]
+    pub funding_rate: f64,
+}
+
+/// The result object for get_funding_chart_data.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingChartDataResult {
+    /// Array of funding chart data points.
+    #[serde(rename = "data")]
+    pub data: Vec<FundingChartDataPoint>,
+}
+
+/// Response for the get_funding_chart_data endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingChartDataResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing funding chart data.
+    #[serde(rename = "result")]
+    pub result: GetFundingChartDataResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_funding_chart_data endpoint.
+    ///
+    /// Retrieves funding chart data for a given instrument name.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_funding_chart_data)
+    pub async fn get_funding_chart_data(&self, params: GetFundingChartDataRequest) -> DeribitResult<GetFundingChartDataResponse> {
+        self.call_public("get_funding_chart_data", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetFundingChartDataRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 7,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"data\": [
+                    { \"timestamp\": 1680307200000, \"funding_rate\": 0.0001 },
+                    { \"timestamp\": 1680310800000, \"funding_rate\": 0.0002 }
+                ]
+            }
+        }"#;
+        let resp: GetFundingChartDataResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 7);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.data.len(), 2);
+        assert!((resp.result.data[0].funding_rate - 0.0001).abs() < 1e-8);
+        assert_eq!(resp.result.data[1].timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_funding_rate_history.rs
+++ b/venues/src/deribit/public/rest/get_funding_rate_history.rs
@@ -1,0 +1,109 @@
+//! Implements the /public/get_funding_rate_history endpoint for Deribit.
+//!
+//! Retrieves historical funding rates for a given instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_funding_rate_history endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetFundingRateHistoryRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Number of data points to retrieve (default 10, max 2000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// End timestamp in milliseconds since epoch (optional).
+    #[serde(rename = "end_timestamp", skip_serializing_if = "Option::is_none")]
+    pub end_timestamp: Option<u64>,
+}
+
+/// Represents a single funding rate history data point.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FundingRateHistoryData {
+    /// Funding rate value.
+    #[serde(rename = "funding_rate")]
+    pub funding_rate: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_funding_rate_history.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingRateHistoryResult {
+    /// Array of funding rate history data points.
+    #[serde(rename = "data")]
+    pub data: Vec<FundingRateHistoryData>,
+}
+
+/// Response for the get_funding_rate_history endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingRateHistoryResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing funding rate history data.
+    #[serde(rename = "result")]
+    pub result: GetFundingRateHistoryResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_funding_rate_history endpoint.
+    ///
+    /// Retrieves historical funding rates for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_funding_rate_history)
+    pub async fn get_funding_rate_history(&self, params: GetFundingRateHistoryRequest) -> DeribitResult<GetFundingRateHistoryResponse> {
+        self.call_public("get_funding_rate_history", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetFundingRateHistoryRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            count: Some(5),
+            end_timestamp: Some(1680310800000),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("count"));
+        assert!(json.contains("end_timestamp"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 8,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"data\": [
+                    { \"funding_rate\": 0.0001, \"timestamp\": 1680307200000 },
+                    { \"funding_rate\": 0.0002, \"timestamp\": 1680310800000 }
+                ]
+            }
+        }"#;
+        let resp: GetFundingRateHistoryResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 8);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.data.len(), 2);
+        assert!((resp.result.data[0].funding_rate - 0.0001).abs() < 1e-8);
+        assert_eq!(resp.result.data[1].timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_funding_rate_history.rs
+++ b/venues/src/deribit/public/rest/get_funding_rate_history.rs
@@ -2,8 +2,9 @@
 //!
 //! Retrieves historical funding rates for a given instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_funding_rate_history endpoint.
@@ -64,7 +65,7 @@ impl RestClient {
     /// Retrieves historical funding rates for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_funding_rate_history)
-    pub async fn get_funding_rate_history(&self, params: GetFundingRateHistoryRequest) -> DeribitResult<GetFundingRateHistoryResponse> {
+    pub async fn get_funding_rate_history(&self, params: GetFundingRateHistoryRequest) -> RestResult<GetFundingRateHistoryResponse> {
         self.call_public("get_funding_rate_history", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_funding_rate_history.rs
+++ b/venues/src/deribit/public/rest/get_funding_rate_history.rs
@@ -3,8 +3,9 @@
 //! Retrieves historical funding rates for a given instrument.
 
 use super::RestClient;
-use crate::deribit::RestResult;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_funding_rate_history endpoint.
@@ -66,7 +67,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_funding_rate_history)
     pub async fn get_funding_rate_history(&self, params: GetFundingRateHistoryRequest) -> RestResult<GetFundingRateHistoryResponse> {
-        self.call_public("get_funding_rate_history", &params).await
+        self.send_request(
+            "get_funding_rate_history",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_funding_rate_value.rs
+++ b/venues/src/deribit/public/rest/get_funding_rate_value.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the current funding rate value for a given instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_funding_rate_value endpoint.
@@ -48,8 +50,14 @@ impl RestClient {
     /// Retrieves the current funding rate value for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_funding_rate_value)
-    pub async fn get_funding_rate_value(&self, params: GetFundingRateValueRequest) -> DeribitResult<GetFundingRateValueResponse> {
-        self.call_public("get_funding_rate_value", &params).await
+    pub async fn get_funding_rate_value(&self, params: GetFundingRateValueRequest) -> RestResult<GetFundingRateValueResponse> {
+        self.send_request(
+            "get_funding_rate_value",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_funding_rate_value.rs
+++ b/venues/src/deribit/public/rest/get_funding_rate_value.rs
@@ -1,0 +1,86 @@
+//! Implements the /public/get_funding_rate_value endpoint for Deribit.
+//!
+//! Retrieves the current funding rate value for a given instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_funding_rate_value endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetFundingRateValueRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_funding_rate_value.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingRateValueResult {
+    /// The current funding rate value.
+    #[serde(rename = "funding_rate")]
+    pub funding_rate: f64,
+
+    /// Timestamp in milliseconds since epoch for the funding rate.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_funding_rate_value endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetFundingRateValueResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the funding rate value.
+    #[serde(rename = "result")]
+    pub result: GetFundingRateValueResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_funding_rate_value endpoint.
+    ///
+    /// Retrieves the current funding rate value for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_funding_rate_value)
+    pub async fn get_funding_rate_value(&self, params: GetFundingRateValueRequest) -> DeribitResult<GetFundingRateValueResponse> {
+        self.call_public("get_funding_rate_value", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetFundingRateValueRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 9,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"funding_rate\": 0.0001,
+                \"timestamp\": 1680310800000
+            }
+        }"#;
+        let resp: GetFundingRateValueResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 9);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert!((resp.result.funding_rate - 0.0001).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_historical_volatility.rs
+++ b/venues/src/deribit/public/rest/get_historical_volatility.rs
@@ -2,13 +2,15 @@
 //!
 //! Retrieves historical volatility data for a given currency.
 
+use super::RestClient;
 use crate::deribit::enums::Currency;
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_historical_volatility endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetHistoricalVolatilityRequest {
     /// Currency for which to retrieve historical volatility.
     #[serde(rename = "currency")]
@@ -65,8 +67,14 @@ impl RestClient {
     /// Retrieves historical volatility data for a given currency.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_historical_volatility)
-    pub async fn get_historical_volatility(&self, params: GetHistoricalVolatilityRequest) -> DeribitResult<GetHistoricalVolatilityResponse> {
-        self.call_public("get_historical_volatility", &params).await
+    pub async fn get_historical_volatility(&self, params: GetHistoricalVolatilityRequest) -> RestResult<GetHistoricalVolatilityResponse> {
+        self.send_request(
+            "get_historical_volatility",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_historical_volatility.rs
+++ b/venues/src/deribit/public/rest/get_historical_volatility.rs
@@ -1,0 +1,110 @@
+//! Implements the /public/get_historical_volatility endpoint for Deribit.
+//!
+//! Retrieves historical volatility data for a given currency.
+
+use crate::deribit::enums::Currency;
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_historical_volatility endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetHistoricalVolatilityRequest {
+    /// Currency for which to retrieve historical volatility.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Number of data points to retrieve (default 365, max 365).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// End timestamp in milliseconds since epoch (optional).
+    #[serde(rename = "end_timestamp", skip_serializing_if = "Option::is_none")]
+    pub end_timestamp: Option<u64>,
+}
+
+/// Represents a single historical volatility data point.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HistoricalVolatilityData {
+    /// Volatility value (annualized, as a percentage).
+    #[serde(rename = "volatility")]
+    pub volatility: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_historical_volatility.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetHistoricalVolatilityResult {
+    /// Array of historical volatility data points.
+    #[serde(rename = "data")]
+    pub data: Vec<HistoricalVolatilityData>,
+}
+
+/// Response for the get_historical_volatility endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetHistoricalVolatilityResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing historical volatility data.
+    #[serde(rename = "result")]
+    pub result: GetHistoricalVolatilityResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_historical_volatility endpoint.
+    ///
+    /// Retrieves historical volatility data for a given currency.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_historical_volatility)
+    pub async fn get_historical_volatility(&self, params: GetHistoricalVolatilityRequest) -> DeribitResult<GetHistoricalVolatilityResponse> {
+        self.call_public("get_historical_volatility", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetHistoricalVolatilityRequest {
+            currency: Currency::BTC,
+            count: Some(10),
+            end_timestamp: Some(1680310800000),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("count"));
+        assert!(json.contains("end_timestamp"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 10,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"data\": [
+                    { \"volatility\": 0.65, \"timestamp\": 1680307200000 },
+                    { \"volatility\": 0.66, \"timestamp\": 1680310800000 }
+                ]
+            }
+        }"#;
+        let resp: GetHistoricalVolatilityResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 10);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.data.len(), 2);
+        assert!((resp.result.data[0].volatility - 0.65).abs() < 1e-8);
+        assert_eq!(resp.result.data[1].timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_index.rs
+++ b/venues/src/deribit/public/rest/get_index.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the current index price for a given index name.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_index endpoint.
@@ -48,8 +50,14 @@ impl RestClient {
     /// Retrieves the current index price for a given index name.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_index)
-    pub async fn get_index(&self, params: GetIndexRequest) -> DeribitResult<GetIndexResponse> {
-        self.call_public("get_index", &params).await
+    pub async fn get_index(&self, params: GetIndexRequest) -> RestResult<GetIndexResponse> {
+        self.send_request(
+            "get_index",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_index.rs
+++ b/venues/src/deribit/public/rest/get_index.rs
@@ -1,0 +1,86 @@
+//! Implements the /public/get_index endpoint for Deribit.
+//!
+//! Retrieves the current index price for a given index name.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_index endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetIndexRequest {
+    /// Index name (e.g., "btc_usd").
+    #[serde(rename = "index_name")]
+    pub index_name: String,
+}
+
+/// The result object for get_index.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexResult {
+    /// The current index price.
+    #[serde(rename = "index_price")]
+    pub index_price: f64,
+
+    /// Timestamp in milliseconds since epoch for the index price.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_index endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the index price.
+    #[serde(rename = "result")]
+    pub result: GetIndexResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_index endpoint.
+    ///
+    /// Retrieves the current index price for a given index name.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_index)
+    pub async fn get_index(&self, params: GetIndexRequest) -> DeribitResult<GetIndexResponse> {
+        self.call_public("get_index", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetIndexRequest {
+            index_name: "btc_usd".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("btc_usd"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 11,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"index_price\": 65000.0,
+                \"timestamp\": 1680310800000
+            }
+        }"#;
+        let resp: GetIndexResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 11);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert!((resp.result.index_price - 65000.0).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_index_price.rs
+++ b/venues/src/deribit/public/rest/get_index_price.rs
@@ -1,0 +1,86 @@
+//! Implements the /public/get_index_price endpoint for Deribit.
+//!
+//! Retrieves the current index price for a given index name (alias for get_index).
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_index_price endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetIndexPriceRequest {
+    /// Index name (e.g., "btc_usd").
+    #[serde(rename = "index_name")]
+    pub index_name: String,
+}
+
+/// The result object for get_index_price.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexPriceResult {
+    /// The current index price.
+    #[serde(rename = "index_price")]
+    pub index_price: f64,
+
+    /// Timestamp in milliseconds since epoch for the index price.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_index_price endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexPriceResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the index price.
+    #[serde(rename = "result")]
+    pub result: GetIndexPriceResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_index_price endpoint.
+    ///
+    /// Retrieves the current index price for a given index name (alias for get_index).
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_index_price)
+    pub async fn get_index_price(&self, params: GetIndexPriceRequest) -> DeribitResult<GetIndexPriceResponse> {
+        self.call_public("get_index_price", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetIndexPriceRequest {
+            index_name: "btc_usd".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("btc_usd"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 12,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"index_price\": 65000.0,
+                \"timestamp\": 1680310800000
+            }
+        }"#;
+        let resp: GetIndexPriceResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 12);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert!((resp.result.index_price - 65000.0).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_index_price.rs
+++ b/venues/src/deribit/public/rest/get_index_price.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the current index price for a given index name (alias for get_index).
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_index_price endpoint.
@@ -48,8 +50,14 @@ impl RestClient {
     /// Retrieves the current index price for a given index name (alias for get_index).
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_index_price)
-    pub async fn get_index_price(&self, params: GetIndexPriceRequest) -> DeribitResult<GetIndexPriceResponse> {
-        self.call_public("get_index_price", &params).await
+    pub async fn get_index_price(&self, params: GetIndexPriceRequest) -> RestResult<GetIndexPriceResponse> {
+        self.send_request(
+            "get_index_price",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_index_price_names.rs
+++ b/venues/src/deribit/public/rest/get_index_price_names.rs
@@ -1,0 +1,75 @@
+//! Implements the /public/get_index_price_names endpoint for Deribit.
+//!
+//! Retrieves the list of all supported index price names.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_index_price_names endpoint.
+/// This endpoint does not require any parameters.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetIndexPriceNamesRequest;
+
+/// The result object for get_index_price_names.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexPriceNamesResult {
+    /// List of all supported index price names (e.g., "btc_usd").
+    #[serde(rename = "index_price_names")]
+    pub index_price_names: Vec<String>,
+}
+
+/// Response for the get_index_price_names endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetIndexPriceNamesResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the list of index price names.
+    #[serde(rename = "result")]
+    pub result: GetIndexPriceNamesResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_index_price_names endpoint.
+    ///
+    /// Retrieves the list of all supported index price names.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_index_price_names)
+    pub async fn get_index_price_names(&self, params: GetIndexPriceNamesRequest) -> DeribitResult<GetIndexPriceNamesResponse> {
+        self.call_public("get_index_price_names", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetIndexPriceNamesRequest;
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 13,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"index_price_names\": [\"btc_usd\", \"eth_usd\"]
+            }
+        }"#;
+        let resp: GetIndexPriceNamesResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 13);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.index_price_names, vec!["btc_usd", "eth_usd"]);
+    }
+}

--- a/venues/src/deribit/public/rest/get_index_price_names.rs
+++ b/venues/src/deribit/public/rest/get_index_price_names.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the list of all supported index price names.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_index_price_names endpoint.
@@ -41,8 +43,14 @@ impl RestClient {
     /// Retrieves the list of all supported index price names.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_index_price_names)
-    pub async fn get_index_price_names(&self, params: GetIndexPriceNamesRequest) -> DeribitResult<GetIndexPriceNamesResponse> {
-        self.call_public("get_index_price_names", &params).await
+    pub async fn get_index_price_names(&self, params: GetIndexPriceNamesRequest) -> RestResult<GetIndexPriceNamesResponse> {
+        self.send_request(
+            "get_index_price_names",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_instrument.rs
+++ b/venues/src/deribit/public/rest/get_instrument.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves instrument data for a given instrument name.
 
+use super::RestClient;
 use crate::deribit::enums::{Currency, InstrumentKind};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_instrument endpoint.
@@ -47,7 +49,10 @@ pub struct InstrumentData {
     pub strike: Option<f64>,
 
     /// Optionally, the expiration timestamp (for expiring instruments).
-    #[serde(rename = "expiration_timestamp", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiration_timestamp",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub expiration_timestamp: Option<u64>,
 
     /// Optionally, the creation timestamp.
@@ -97,8 +102,14 @@ impl RestClient {
     /// Retrieves instrument data for a given instrument name.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_instrument)
-    pub async fn get_instrument(&self, params: GetInstrumentRequest) -> DeribitResult<GetInstrumentResponse> {
-        self.call_public("get_instrument", &params).await
+    pub async fn get_instrument(&self, params: GetInstrumentRequest) -> RestResult<GetInstrumentResponse> {
+        self.send_request(
+            "get_instrument",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_instrument.rs
+++ b/venues/src/deribit/public/rest/get_instrument.rs
@@ -1,0 +1,147 @@
+//! Implements the /public/get_instrument endpoint for Deribit.
+//!
+//! Retrieves instrument data for a given instrument name.
+
+use crate::deribit::enums::{Currency, InstrumentKind};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_instrument endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetInstrumentRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// Instrument data returned by get_instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstrumentData {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Currency of the instrument.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind")]
+    pub kind: InstrumentKind,
+
+    /// Tick size for the instrument.
+    #[serde(rename = "tick_size")]
+    pub tick_size: f64,
+
+    /// Contract size for the instrument.
+    #[serde(rename = "contract_size")]
+    pub contract_size: f64,
+
+    /// Minimum trade amount.
+    #[serde(rename = "min_trade_amount")]
+    pub min_trade_amount: f64,
+
+    /// Optionally, the strike price (for options).
+    #[serde(rename = "strike", skip_serializing_if = "Option::is_none")]
+    pub strike: Option<f64>,
+
+    /// Optionally, the expiration timestamp (for expiring instruments).
+    #[serde(rename = "expiration_timestamp", skip_serializing_if = "Option::is_none")]
+    pub expiration_timestamp: Option<u64>,
+
+    /// Optionally, the creation timestamp.
+    #[serde(rename = "creation_timestamp", skip_serializing_if = "Option::is_none")]
+    pub creation_timestamp: Option<u64>,
+
+    /// Optionally, the settlement period (for expiring instruments).
+    #[serde(rename = "settlement_period", skip_serializing_if = "Option::is_none")]
+    pub settlement_period: Option<String>,
+
+    /// Optionally, the base currency (for spot pairs).
+    #[serde(rename = "base_currency", skip_serializing_if = "Option::is_none")]
+    pub base_currency: Option<Currency>,
+
+    /// Optionally, the quote currency (for spot pairs).
+    #[serde(rename = "quote_currency", skip_serializing_if = "Option::is_none")]
+    pub quote_currency: Option<Currency>,
+}
+
+/// The result object for get_instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetInstrumentResult {
+    /// Instrument data.
+    #[serde(rename = "instrument")]
+    pub instrument: InstrumentData,
+}
+
+/// Response for the get_instrument endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetInstrumentResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing instrument data.
+    #[serde(rename = "result")]
+    pub result: GetInstrumentResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_instrument endpoint.
+    ///
+    /// Retrieves instrument data for a given instrument name.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_instrument)
+    pub async fn get_instrument(&self, params: GetInstrumentRequest) -> DeribitResult<GetInstrumentResponse> {
+        self.call_public("get_instrument", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::Currency;
+    use crate::deribit::enums::InstrumentKind;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetInstrumentRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 14,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"instrument\": {
+                    \"instrument_name\": \"BTC-PERPETUAL\",
+                    \"currency\": \"BTC\",
+                    \"kind\": \"future\",
+                    \"tick_size\": 0.5,
+                    \"contract_size\": 10.0,
+                    \"min_trade_amount\": 1.0
+                }
+            }
+        }"#;
+        let resp: GetInstrumentResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 14);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.instrument.instrument_name, "BTC-PERPETUAL");
+        assert_eq!(resp.result.instrument.currency, Currency::BTC);
+        assert_eq!(resp.result.instrument.kind, InstrumentKind::Future);
+        assert!((resp.result.instrument.tick_size - 0.5).abs() < 1e-8);
+        assert!((resp.result.instrument.contract_size - 10.0).abs() < 1e-8);
+        assert!((resp.result.instrument.min_trade_amount - 1.0).abs() < 1e-8);
+    }
+}

--- a/venues/src/deribit/public/rest/get_instruments.rs
+++ b/venues/src/deribit/public/rest/get_instruments.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves a list of instruments for a given currency and kind.
 
+use super::RestClient;
 use crate::deribit::enums::{Currency, InstrumentKind};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_instruments endpoint.
@@ -55,7 +57,10 @@ pub struct InstrumentData {
     pub strike: Option<f64>,
 
     /// Optionally, the expiration timestamp (for expiring instruments).
-    #[serde(rename = "expiration_timestamp", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "expiration_timestamp",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub expiration_timestamp: Option<u64>,
 
     /// Optionally, the creation timestamp.
@@ -105,8 +110,14 @@ impl RestClient {
     /// Retrieves a list of instruments for a given currency and kind.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_instruments)
-    pub async fn get_instruments(&self, params: GetInstrumentsRequest) -> DeribitResult<GetInstrumentsResponse> {
-        self.call_public("get_instruments", &params).await
+    pub async fn get_instruments(&self, params: GetInstrumentsRequest) -> RestResult<GetInstrumentsResponse> {
+        self.send_request(
+            "get_instruments",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_instruments.rs
+++ b/venues/src/deribit/public/rest/get_instruments.rs
@@ -1,0 +1,162 @@
+//! Implements the /public/get_instruments endpoint for Deribit.
+//!
+//! Retrieves a list of instruments for a given currency and kind.
+
+use crate::deribit::enums::{Currency, InstrumentKind};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_instruments endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetInstrumentsRequest {
+    /// Currency for which to retrieve instruments.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<InstrumentKind>,
+
+    /// Whether to include expired instruments (default: false).
+    #[serde(rename = "expired", skip_serializing_if = "Option::is_none")]
+    pub expired: Option<bool>,
+}
+
+/// Instrument data returned by get_instruments.
+#[derive(Debug, Clone, Deserialize)]
+pub struct InstrumentData {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Currency of the instrument.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind")]
+    pub kind: InstrumentKind,
+
+    /// Tick size for the instrument.
+    #[serde(rename = "tick_size")]
+    pub tick_size: f64,
+
+    /// Contract size for the instrument.
+    #[serde(rename = "contract_size")]
+    pub contract_size: f64,
+
+    /// Minimum trade amount.
+    #[serde(rename = "min_trade_amount")]
+    pub min_trade_amount: f64,
+
+    /// Optionally, the strike price (for options).
+    #[serde(rename = "strike", skip_serializing_if = "Option::is_none")]
+    pub strike: Option<f64>,
+
+    /// Optionally, the expiration timestamp (for expiring instruments).
+    #[serde(rename = "expiration_timestamp", skip_serializing_if = "Option::is_none")]
+    pub expiration_timestamp: Option<u64>,
+
+    /// Optionally, the creation timestamp.
+    #[serde(rename = "creation_timestamp", skip_serializing_if = "Option::is_none")]
+    pub creation_timestamp: Option<u64>,
+
+    /// Optionally, the settlement period (for expiring instruments).
+    #[serde(rename = "settlement_period", skip_serializing_if = "Option::is_none")]
+    pub settlement_period: Option<String>,
+
+    /// Optionally, the base currency (for spot pairs).
+    #[serde(rename = "base_currency", skip_serializing_if = "Option::is_none")]
+    pub base_currency: Option<Currency>,
+
+    /// Optionally, the quote currency (for spot pairs).
+    #[serde(rename = "quote_currency", skip_serializing_if = "Option::is_none")]
+    pub quote_currency: Option<Currency>,
+}
+
+/// The result object for get_instruments.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetInstrumentsResult {
+    /// List of instrument data.
+    #[serde(rename = "instruments")]
+    pub instruments: Vec<InstrumentData>,
+}
+
+/// Response for the get_instruments endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetInstrumentsResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the list of instruments.
+    #[serde(rename = "result")]
+    pub result: GetInstrumentsResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_instruments endpoint.
+    ///
+    /// Retrieves a list of instruments for a given currency and kind.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_instruments)
+    pub async fn get_instruments(&self, params: GetInstrumentsRequest) -> DeribitResult<GetInstrumentsResponse> {
+        self.call_public("get_instruments", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::Currency;
+    use crate::deribit::enums::InstrumentKind;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetInstrumentsRequest {
+            currency: Currency::BTC,
+            kind: Some(InstrumentKind::Future),
+            expired: Some(false),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("future"));
+        assert!(json.contains("expired"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 15,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"instruments\": [
+                    {
+                        \"instrument_name\": \"BTC-PERPETUAL\",
+                        \"currency\": \"BTC\",
+                        \"kind\": \"future\",
+                        \"tick_size\": 0.5,
+                        \"contract_size\": 10.0,
+                        \"min_trade_amount\": 1.0
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetInstrumentsResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 15);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.instruments.len(), 1);
+        assert_eq!(resp.result.instruments[0].instrument_name, "BTC-PERPETUAL");
+        assert_eq!(resp.result.instruments[0].currency, Currency::BTC);
+        assert_eq!(resp.result.instruments[0].kind, InstrumentKind::Future);
+        assert!((resp.result.instruments[0].tick_size - 0.5).abs() < 1e-8);
+        assert!((resp.result.instruments[0].contract_size - 10.0).abs() < 1e-8);
+        assert!((resp.result.instruments[0].min_trade_amount - 1.0).abs() < 1e-8);
+    }
+}

--- a/venues/src/deribit/public/rest/get_instruments.rs
+++ b/venues/src/deribit/public/rest/get_instruments.rs
@@ -10,7 +10,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_instruments endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetInstrumentsRequest {
     /// Currency for which to retrieve instruments.
     #[serde(rename = "currency")]

--- a/venues/src/deribit/public/rest/get_last_settlements_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_last_settlements_by_currency.rs
@@ -1,0 +1,119 @@
+//! Implements the /public/get_last_settlements_by_currency endpoint for Deribit.
+//!
+//! Retrieves the most recent settlements for a given currency and instrument kind.
+
+use crate::deribit::enums::{Currency, InstrumentKind};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_settlements_by_currency endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastSettlementsByCurrencyRequest {
+    /// Currency for which to retrieve settlements.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind")]
+    pub kind: InstrumentKind,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}
+
+/// Represents a single settlement entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettlementEntry {
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Settlement price.
+    #[serde(rename = "settlement_price")]
+    pub settlement_price: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_last_settlements_by_currency.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastSettlementsByCurrencyResult {
+    /// List of settlement entries.
+    #[serde(rename = "settlements")]
+    pub settlements: Vec<SettlementEntry>,
+}
+
+/// Response for the get_last_settlements_by_currency endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastSettlementsByCurrencyResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the settlements.
+    #[serde(rename = "result")]
+    pub result: GetLastSettlementsByCurrencyResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_settlements_by_currency endpoint.
+    ///
+    /// Retrieves the most recent settlements for a given currency and instrument kind.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_settlements_by_currency)
+    pub async fn get_last_settlements_by_currency(&self, params: GetLastSettlementsByCurrencyRequest) -> DeribitResult<GetLastSettlementsByCurrencyResponse> {
+        self.call_public("get_last_settlements_by_currency", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::{Currency, InstrumentKind};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastSettlementsByCurrencyRequest {
+            currency: Currency::BTC,
+            kind: InstrumentKind::Future,
+            count: Some(5),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("future"));
+        assert!(json.contains("count"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 16,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"settlements\": [
+                    {
+                        \"instrument_name\": \"BTC-PERPETUAL\",
+                        \"settlement_price\": 65000.0,
+                        \"timestamp\": 1680310800000
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastSettlementsByCurrencyResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 16);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.settlements.len(), 1);
+        assert_eq!(resp.result.settlements[0].instrument_name, "BTC-PERPETUAL");
+        assert!((resp.result.settlements[0].settlement_price - 65000.0).abs() < 1e-8);
+        assert_eq!(resp.result.settlements[0].timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_last_settlements_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_last_settlements_by_currency.rs
@@ -2,13 +2,15 @@
 //!
 //! Retrieves the most recent settlements for a given currency and instrument kind.
 
+use super::RestClient;
 use crate::deribit::enums::{Currency, InstrumentKind};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_settlements_by_currency endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetLastSettlementsByCurrencyRequest {
     /// Currency for which to retrieve settlements.
     #[serde(rename = "currency")]
@@ -69,8 +71,14 @@ impl RestClient {
     /// Retrieves the most recent settlements for a given currency and instrument kind.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_settlements_by_currency)
-    pub async fn get_last_settlements_by_currency(&self, params: GetLastSettlementsByCurrencyRequest) -> DeribitResult<GetLastSettlementsByCurrencyResponse> {
-        self.call_public("get_last_settlements_by_currency", &params).await
+    pub async fn get_last_settlements_by_currency(&self, params: GetLastSettlementsByCurrencyRequest) -> RestResult<GetLastSettlementsByCurrencyResponse> {
+        self.send_request(
+            "get_last_settlements_by_currency",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_last_settlements_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_last_settlements_by_instrument.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the most recent settlements for a given instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_settlements_by_instrument endpoint.
@@ -64,8 +66,17 @@ impl RestClient {
     /// Retrieves the most recent settlements for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_settlements_by_instrument)
-    pub async fn get_last_settlements_by_instrument(&self, params: GetLastSettlementsByInstrumentRequest) -> DeribitResult<GetLastSettlementsByInstrumentResponse> {
-        self.call_public("get_last_settlements_by_instrument", &params).await
+    pub async fn get_last_settlements_by_instrument(
+        &self,
+        params: GetLastSettlementsByInstrumentRequest,
+    ) -> RestResult<GetLastSettlementsByInstrumentResponse> {
+        self.send_request(
+            "get_last_settlements_by_instrument",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_last_settlements_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_last_settlements_by_instrument.rs
@@ -1,0 +1,111 @@
+//! Implements the /public/get_last_settlements_by_instrument endpoint for Deribit.
+//!
+//! Retrieves the most recent settlements for a given instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_settlements_by_instrument endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastSettlementsByInstrumentRequest {
+    /// Instrument name for which to retrieve settlements.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}
+
+/// Represents a single settlement entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettlementEntry {
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Settlement price.
+    #[serde(rename = "settlement_price")]
+    pub settlement_price: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_last_settlements_by_instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastSettlementsByInstrumentResult {
+    /// List of settlement entries.
+    #[serde(rename = "settlements")]
+    pub settlements: Vec<SettlementEntry>,
+}
+
+/// Response for the get_last_settlements_by_instrument endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastSettlementsByInstrumentResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the settlements.
+    #[serde(rename = "result")]
+    pub result: GetLastSettlementsByInstrumentResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_settlements_by_instrument endpoint.
+    ///
+    /// Retrieves the most recent settlements for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_settlements_by_instrument)
+    pub async fn get_last_settlements_by_instrument(&self, params: GetLastSettlementsByInstrumentRequest) -> DeribitResult<GetLastSettlementsByInstrumentResponse> {
+        self.call_public("get_last_settlements_by_instrument", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastSettlementsByInstrumentRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            count: Some(3),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("count"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 17,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"settlements\": [
+                    {
+                        \"instrument_name\": \"BTC-PERPETUAL\",
+                        \"settlement_price\": 65000.0,
+                        \"timestamp\": 1680310800000
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastSettlementsByInstrumentResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 17);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.settlements.len(), 1);
+        assert_eq!(resp.result.settlements[0].instrument_name, "BTC-PERPETUAL");
+        assert!((resp.result.settlements[0].settlement_price - 65000.0).abs() < 1e-8);
+        assert_eq!(resp.result.settlements[0].timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
@@ -1,0 +1,155 @@
+//! Implements the /public/get_last_trades_by_currency endpoint for Deribit.
+//!
+//! Retrieves the most recent trades for a given currency and instrument kind.
+
+use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_trades_by_currency endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastTradesByCurrencyRequest {
+    /// Currency for which to retrieve trades.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind")]
+    pub kind: InstrumentKind,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// Sorting direction (asc, desc, default).
+    #[serde(rename = "sorting", skip_serializing_if = "Option::is_none")]
+    pub sorting: Option<Sorting>,
+}
+
+/// Represents a single trade entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradeEntry {
+    /// Trade ID.
+    #[serde(rename = "trade_id")]
+    pub trade_id: String,
+
+    /// Price at which the trade occurred.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount traded.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+
+    /// Tick direction (enum).
+    #[serde(rename = "tick_direction")]
+    pub tick_direction: TickDirection,
+
+    /// Liquidity role (maker/taker).
+    #[serde(rename = "liquidity")]
+    pub liquidity: Liquidity,
+
+    /// Trade order type (limit/market/liquidation).
+    #[serde(rename = "order_type")]
+    pub order_type: TradeOrderType,
+
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_last_trades_by_currency.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByCurrencyResult {
+    /// List of trade entries.
+    #[serde(rename = "trades")]
+    pub trades: Vec<TradeEntry>,
+}
+
+/// Response for the get_last_trades_by_currency endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByCurrencyResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the trades.
+    #[serde(rename = "result")]
+    pub result: GetLastTradesByCurrencyResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_trades_by_currency endpoint.
+    ///
+    /// Retrieves the most recent trades for a given currency and instrument kind.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_currency)
+    pub async fn get_last_trades_by_currency(&self, params: GetLastTradesByCurrencyRequest) -> DeribitResult<GetLastTradesByCurrencyResponse> {
+        self.call_public("get_last_trades_by_currency", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastTradesByCurrencyRequest {
+            currency: Currency::BTC,
+            kind: InstrumentKind::Future,
+            count: Some(2),
+            sorting: Some(Sorting::Desc),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("future"));
+        assert!(json.contains("desc"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 18,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"trades\": [
+                    {
+                        \"trade_id\": \"123456\",
+                        \"price\": 65000.0,
+                        \"amount\": 0.1,
+                        \"timestamp\": 1680310800000,
+                        \"tick_direction\": "0",
+                        \"liquidity\": "M",
+                        \"order_type\": "limit",
+                        \"instrument_name\": "BTC-PERPETUAL"
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastTradesByCurrencyResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 18);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.trades.len(), 1);
+        let trade = &resp.result.trades[0];
+        assert_eq!(trade.trade_id, "123456");
+        assert!((trade.price - 65000.0).abs() < 1e-8);
+        assert!((trade.amount - 0.1).abs() < 1e-8);
+        assert_eq!(trade.timestamp, 1680310800000);
+        assert_eq!(trade.tick_direction, TickDirection::PlusTick);
+        assert_eq!(trade.liquidity, Liquidity::Maker);
+        assert_eq!(trade.order_type, TradeOrderType::Limit);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
@@ -2,13 +2,14 @@
 //!
 //! Retrieves the most recent trades for a given currency and instrument kind.
 
-use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+use crate::deribit::enums::{Currency, InstrumentKind, Liquidity, Sorting, TickDirection, TradeOrderType};
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_currency endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetLastTradesByCurrencyRequest {
     /// Currency for which to retrieve trades.
     #[serde(rename = "currency")]
@@ -93,15 +94,16 @@ impl RestClient {
     /// Retrieves the most recent trades for a given currency and instrument kind.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_currency)
-    pub async fn get_last_trades_by_currency(&self, params: GetLastTradesByCurrencyRequest) -> DeribitResult<GetLastTradesByCurrencyResponse> {
-        self.call_public("get_last_trades_by_currency", &params).await
+    pub async fn get_last_trades_by_currency(&self, params: GetLastTradesByCurrencyRequest) -> RestResult<GetLastTradesByCurrencyResponse> {
+        self.call_public("get_last_trades_by_currency", &params)
+            .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+    use crate::deribit::enums::{Currency, InstrumentKind, Liquidity, Sorting, TickDirection, TradeOrderType};
     use serde_json;
 
     #[test]

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency.rs
@@ -3,9 +3,10 @@
 //! Retrieves the most recent trades for a given currency and instrument kind.
 
 use super::RestClient;
-use crate::deribit::RestResult;
 use crate::deribit::enums::{Currency, InstrumentKind, Liquidity, Sorting, TickDirection, TradeOrderType};
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_currency endpoint.
@@ -95,8 +96,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_currency)
     pub async fn get_last_trades_by_currency(&self, params: GetLastTradesByCurrencyRequest) -> RestResult<GetLastTradesByCurrencyResponse> {
-        self.call_public("get_last_trades_by_currency", &params)
-            .await
+        self.send_request(
+            "get_last_trades_by_currency",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
@@ -1,0 +1,167 @@
+//! Implements the /public/get_last_trades_by_currency_and_time endpoint for Deribit.
+//!
+//! Retrieves the most recent trades for a given currency and instrument kind, filtered by start and end timestamps.
+
+use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_trades_by_currency_and_time endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastTradesByCurrencyAndTimeRequest {
+    /// Currency for which to retrieve trades.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Kind of the instrument (future, option, etc.).
+    #[serde(rename = "kind")]
+    pub kind: InstrumentKind,
+
+    /// Start timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "start_timestamp")]
+    pub start_timestamp: u64,
+
+    /// End timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "end_timestamp")]
+    pub end_timestamp: u64,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// Sorting direction (asc, desc, default).
+    #[serde(rename = "sorting", skip_serializing_if = "Option::is_none")]
+    pub sorting: Option<Sorting>,
+}
+
+/// Represents a single trade entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradeEntry {
+    /// Trade ID.
+    #[serde(rename = "trade_id")]
+    pub trade_id: String,
+
+    /// Price at which the trade occurred.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount traded.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+
+    /// Tick direction (enum).
+    #[serde(rename = "tick_direction")]
+    pub tick_direction: TickDirection,
+
+    /// Liquidity role (maker/taker).
+    #[serde(rename = "liquidity")]
+    pub liquidity: Liquidity,
+
+    /// Trade order type (limit/market/liquidation).
+    #[serde(rename = "order_type")]
+    pub order_type: TradeOrderType,
+
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_last_trades_by_currency_and_time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByCurrencyAndTimeResult {
+    /// List of trade entries.
+    #[serde(rename = "trades")]
+    pub trades: Vec<TradeEntry>,
+}
+
+/// Response for the get_last_trades_by_currency_and_time endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByCurrencyAndTimeResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the trades.
+    #[serde(rename = "result")]
+    pub result: GetLastTradesByCurrencyAndTimeResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_trades_by_currency_and_time endpoint.
+    ///
+    /// Retrieves the most recent trades for a given currency and instrument kind, filtered by start and end timestamps.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_currency_and_time)
+    pub async fn get_last_trades_by_currency_and_time(&self, params: GetLastTradesByCurrencyAndTimeRequest) -> DeribitResult<GetLastTradesByCurrencyAndTimeResponse> {
+        self.call_public("get_last_trades_by_currency_and_time", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastTradesByCurrencyAndTimeRequest {
+            currency: Currency::BTC,
+            kind: InstrumentKind::Future,
+            start_timestamp: 1680310000000,
+            end_timestamp: 1680310800000,
+            count: Some(2),
+            sorting: Some(Sorting::Asc),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC"));
+        assert!(json.contains("future"));
+        assert!(json.contains("1680310000000"));
+        assert!(json.contains("1680310800000"));
+        assert!(json.contains("asc"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 19,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"trades\": [
+                    {
+                        \"trade_id\": \"123457\",
+                        \"price\": 65000.0,
+                        \"amount\": 0.2,
+                        \"timestamp\": 1680310800000,
+                        \"tick_direction\": "1",
+                        \"liquidity\": "T",
+                        \"order_type\": "market",
+                        \"instrument_name\": "BTC-PERPETUAL"
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastTradesByCurrencyAndTimeResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 19);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.trades.len(), 1);
+        let trade = &resp.result.trades[0];
+        assert_eq!(trade.trade_id, "123457");
+        assert!((trade.price - 65000.0).abs() < 1e-8);
+        assert!((trade.amount - 0.2).abs() < 1e-8);
+        assert_eq!(trade.timestamp, 1680310800000);
+        assert_eq!(trade.tick_direction, TickDirection::ZeroPlusTick);
+        assert_eq!(trade.liquidity, Liquidity::Taker);
+        assert_eq!(trade.order_type, TradeOrderType::Market);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves the most recent trades for a given currency and instrument kind, filtered by start and end timestamps.
 
-use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::enums::{Currency, InstrumentKind, Liquidity, Sorting, TickDirection, TradeOrderType};
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_currency_and_time endpoint.
@@ -101,15 +103,24 @@ impl RestClient {
     /// Retrieves the most recent trades for a given currency and instrument kind, filtered by start and end timestamps.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_currency_and_time)
-    pub async fn get_last_trades_by_currency_and_time(&self, params: GetLastTradesByCurrencyAndTimeRequest) -> DeribitResult<GetLastTradesByCurrencyAndTimeResponse> {
-        self.call_public("get_last_trades_by_currency_and_time", &params).await
+    pub async fn get_last_trades_by_currency_and_time(
+        &self,
+        params: GetLastTradesByCurrencyAndTimeRequest,
+    ) -> RestResult<GetLastTradesByCurrencyAndTimeResponse> {
+        self.send_request(
+            "get_last_trades_by_currency_and_time",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deribit::enums::{Currency, InstrumentKind, Sorting, TickDirection, Liquidity, TradeOrderType};
+    use crate::deribit::enums::{Currency, InstrumentKind, Liquidity, Sorting, TickDirection, TradeOrderType};
     use serde_json;
 
     #[test]

--- a/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_currency_and_time.rs
@@ -10,7 +10,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_currency_and_time endpoint.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetLastTradesByCurrencyAndTimeRequest {
     /// Currency for which to retrieve trades.
     #[serde(rename = "currency")]

--- a/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
@@ -3,9 +3,10 @@
 //! Retrieves the most recent trades for a given instrument.
 
 use super::RestClient;
-use crate::deribit::RestResult;
 use crate::deribit::enums::{Liquidity, Sorting, TickDirection, TradeOrderType};
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_instrument endpoint.
@@ -91,8 +92,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_instrument)
     pub async fn get_last_trades_by_instrument(&self, params: GetLastTradesByInstrumentRequest) -> RestResult<GetLastTradesByInstrumentResponse> {
-        self.call_public("get_last_trades_by_instrument", &params)
-            .await
+        self.send_request(
+            "get_last_trades_by_instrument",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
@@ -1,0 +1,149 @@
+//! Implements the /public/get_last_trades_by_instrument endpoint for Deribit.
+//!
+//! Retrieves the most recent trades for a given instrument.
+
+use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_trades_by_instrument endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastTradesByInstrumentRequest {
+    /// Instrument name for which to retrieve trades.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// Sorting direction (asc, desc, default).
+    #[serde(rename = "sorting", skip_serializing_if = "Option::is_none")]
+    pub sorting: Option<Sorting>,
+}
+
+/// Represents a single trade entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradeEntry {
+    /// Trade ID.
+    #[serde(rename = "trade_id")]
+    pub trade_id: String,
+
+    /// Price at which the trade occurred.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount traded.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+
+    /// Tick direction (enum).
+    #[serde(rename = "tick_direction")]
+    pub tick_direction: TickDirection,
+
+    /// Liquidity role (maker/taker).
+    #[serde(rename = "liquidity")]
+    pub liquidity: Liquidity,
+
+    /// Trade order type (limit/market/liquidation).
+    #[serde(rename = "order_type")]
+    pub order_type: TradeOrderType,
+
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_last_trades_by_instrument.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByInstrumentResult {
+    /// List of trade entries.
+    #[serde(rename = "trades")]
+    pub trades: Vec<TradeEntry>,
+}
+
+/// Response for the get_last_trades_by_instrument endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByInstrumentResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the trades.
+    #[serde(rename = "result")]
+    pub result: GetLastTradesByInstrumentResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_trades_by_instrument endpoint.
+    ///
+    /// Retrieves the most recent trades for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_instrument)
+    pub async fn get_last_trades_by_instrument(&self, params: GetLastTradesByInstrumentRequest) -> DeribitResult<GetLastTradesByInstrumentResponse> {
+        self.call_public("get_last_trades_by_instrument", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastTradesByInstrumentRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            count: Some(2),
+            sorting: Some(Sorting::Desc),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("desc"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 20,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"trades\": [
+                    {
+                        \"trade_id\": \"123458\",
+                        \"price\": 65000.0,
+                        \"amount\": 0.3,
+                        \"timestamp\": 1680310800000,
+                        \"tick_direction\": "2",
+                        \"liquidity\": "T",
+                        \"order_type\": "market",
+                        \"instrument_name\": "BTC-PERPETUAL"
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastTradesByInstrumentResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 20);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.trades.len(), 1);
+        let trade = &resp.result.trades[0];
+        assert_eq!(trade.trade_id, "123458");
+        assert!((trade.price - 65000.0).abs() < 1e-8);
+        assert!((trade.amount - 0.3).abs() < 1e-8);
+        assert_eq!(trade.timestamp, 1680310800000);
+        assert_eq!(trade.tick_direction, TickDirection::MinusTick);
+        assert_eq!(trade.liquidity, Liquidity::Taker);
+        assert_eq!(trade.order_type, TradeOrderType::Market);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_instrument.rs
@@ -2,9 +2,10 @@
 //!
 //! Retrieves the most recent trades for a given instrument.
 
-use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+use crate::deribit::enums::{Liquidity, Sorting, TickDirection, TradeOrderType};
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_instrument endpoint.
@@ -89,15 +90,16 @@ impl RestClient {
     /// Retrieves the most recent trades for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_instrument)
-    pub async fn get_last_trades_by_instrument(&self, params: GetLastTradesByInstrumentRequest) -> DeribitResult<GetLastTradesByInstrumentResponse> {
-        self.call_public("get_last_trades_by_instrument", &params).await
+    pub async fn get_last_trades_by_instrument(&self, params: GetLastTradesByInstrumentRequest) -> RestResult<GetLastTradesByInstrumentResponse> {
+        self.call_public("get_last_trades_by_instrument", &params)
+            .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+    use crate::deribit::enums::{Liquidity, Sorting, TickDirection, TradeOrderType};
     use serde_json;
 
     #[test]

--- a/venues/src/deribit/public/rest/get_last_trades_by_instrument_and_time.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_instrument_and_time.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves the most recent trades for a given instrument, filtered by start and end timestamps.
 
-use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::enums::{Liquidity, Sorting, TickDirection, TradeOrderType};
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_last_trades_by_instrument_and_time endpoint.
@@ -97,15 +99,24 @@ impl RestClient {
     /// Retrieves the most recent trades for a given instrument, filtered by start and end timestamps.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_instrument_and_time)
-    pub async fn get_last_trades_by_instrument_and_time(&self, params: GetLastTradesByInstrumentAndTimeRequest) -> DeribitResult<GetLastTradesByInstrumentAndTimeResponse> {
-        self.call_public("get_last_trades_by_instrument_and_time", &params).await
+    pub async fn get_last_trades_by_instrument_and_time(
+        &self,
+        params: GetLastTradesByInstrumentAndTimeRequest,
+    ) -> RestResult<GetLastTradesByInstrumentAndTimeResponse> {
+        self.send_request(
+            "get_last_trades_by_instrument_and_time",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+    use crate::deribit::enums::{Liquidity, Sorting, TickDirection, TradeOrderType};
     use serde_json;
 
     #[test]

--- a/venues/src/deribit/public/rest/get_last_trades_by_instrument_and_time.rs
+++ b/venues/src/deribit/public/rest/get_last_trades_by_instrument_and_time.rs
@@ -1,0 +1,161 @@
+//! Implements the /public/get_last_trades_by_instrument_and_time endpoint for Deribit.
+//!
+//! Retrieves the most recent trades for a given instrument, filtered by start and end timestamps.
+
+use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_last_trades_by_instrument_and_time endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetLastTradesByInstrumentAndTimeRequest {
+    /// Instrument name for which to retrieve trades.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Start timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "start_timestamp")]
+    pub start_timestamp: u64,
+
+    /// End timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "end_timestamp")]
+    pub end_timestamp: u64,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+
+    /// Sorting direction (asc, desc, default).
+    #[serde(rename = "sorting", skip_serializing_if = "Option::is_none")]
+    pub sorting: Option<Sorting>,
+}
+
+/// Represents a single trade entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradeEntry {
+    /// Trade ID.
+    #[serde(rename = "trade_id")]
+    pub trade_id: String,
+
+    /// Price at which the trade occurred.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount traded.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+
+    /// Tick direction (enum).
+    #[serde(rename = "tick_direction")]
+    pub tick_direction: TickDirection,
+
+    /// Liquidity role (maker/taker).
+    #[serde(rename = "liquidity")]
+    pub liquidity: Liquidity,
+
+    /// Trade order type (limit/market/liquidation).
+    #[serde(rename = "order_type")]
+    pub order_type: TradeOrderType,
+
+    /// Instrument name.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+}
+
+/// The result object for get_last_trades_by_instrument_and_time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByInstrumentAndTimeResult {
+    /// List of trade entries.
+    #[serde(rename = "trades")]
+    pub trades: Vec<TradeEntry>,
+}
+
+/// Response for the get_last_trades_by_instrument_and_time endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetLastTradesByInstrumentAndTimeResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the trades.
+    #[serde(rename = "result")]
+    pub result: GetLastTradesByInstrumentAndTimeResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_last_trades_by_instrument_and_time endpoint.
+    ///
+    /// Retrieves the most recent trades for a given instrument, filtered by start and end timestamps.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_last_trades_by_instrument_and_time)
+    pub async fn get_last_trades_by_instrument_and_time(&self, params: GetLastTradesByInstrumentAndTimeRequest) -> DeribitResult<GetLastTradesByInstrumentAndTimeResponse> {
+        self.call_public("get_last_trades_by_instrument_and_time", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::{Sorting, TickDirection, Liquidity, TradeOrderType};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetLastTradesByInstrumentAndTimeRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            start_timestamp: 1680310000000,
+            end_timestamp: 1680310800000,
+            count: Some(2),
+            sorting: Some(Sorting::Asc),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("1680310000000"));
+        assert!(json.contains("1680310800000"));
+        assert!(json.contains("asc"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 21,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"trades\": [
+                    {
+                        \"trade_id\": \"123459\",
+                        \"price\": 65000.0,
+                        \"amount\": 0.4,
+                        \"timestamp\": 1680310800000,
+                        \"tick_direction\": "3",
+                        \"liquidity\": "M",
+                        \"order_type\": "limit",
+                        \"instrument_name\": "BTC-PERPETUAL"
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetLastTradesByInstrumentAndTimeResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 21);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.trades.len(), 1);
+        let trade = &resp.result.trades[0];
+        assert_eq!(trade.trade_id, "123459");
+        assert!((trade.price - 65000.0).abs() < 1e-8);
+        assert!((trade.amount - 0.4).abs() < 1e-8);
+        assert_eq!(trade.timestamp, 1680310800000);
+        assert_eq!(trade.tick_direction, TickDirection::ZeroMinusTick);
+        assert_eq!(trade.liquidity, Liquidity::Maker);
+        assert_eq!(trade.order_type, TradeOrderType::Limit);
+        assert_eq!(trade.instrument_name, "BTC-PERPETUAL");
+    }
+}

--- a/venues/src/deribit/public/rest/get_mark_price_history.rs
+++ b/venues/src/deribit/public/rest/get_mark_price_history.rs
@@ -3,8 +3,9 @@
 //! Retrieves historical mark prices for a given instrument.
 
 use super::RestClient;
-use crate::deribit::RestResult;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_mark_price_history endpoint.
@@ -70,7 +71,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_mark_price_history)
     pub async fn get_mark_price_history(&self, params: GetMarkPriceHistoryRequest) -> RestResult<GetMarkPriceHistoryResponse> {
-        self.call_public("get_mark_price_history", &params).await
+        self.send_request(
+            "get_mark_price_history",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_mark_price_history.rs
+++ b/venues/src/deribit/public/rest/get_mark_price_history.rs
@@ -2,8 +2,9 @@
 //!
 //! Retrieves historical mark prices for a given instrument.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_mark_price_history endpoint.
@@ -68,7 +69,7 @@ impl RestClient {
     /// Retrieves historical mark prices for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_mark_price_history)
-    pub async fn get_mark_price_history(&self, params: GetMarkPriceHistoryRequest) -> DeribitResult<GetMarkPriceHistoryResponse> {
+    pub async fn get_mark_price_history(&self, params: GetMarkPriceHistoryRequest) -> RestResult<GetMarkPriceHistoryResponse> {
         self.call_public("get_mark_price_history", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_mark_price_history.rs
+++ b/venues/src/deribit/public/rest/get_mark_price_history.rs
@@ -1,0 +1,118 @@
+//! Implements the /public/get_mark_price_history endpoint for Deribit.
+//!
+//! Retrieves historical mark prices for a given instrument.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_mark_price_history endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetMarkPriceHistoryRequest {
+    /// Instrument name for which to retrieve mark price history.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Start timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "start_timestamp")]
+    pub start_timestamp: u64,
+
+    /// End timestamp in milliseconds since epoch (inclusive).
+    #[serde(rename = "end_timestamp")]
+    pub end_timestamp: u64,
+
+    /// Number of data points to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}
+
+/// Represents a single mark price entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MarkPriceEntry {
+    /// Mark price at the given timestamp.
+    #[serde(rename = "mark_price")]
+    pub mark_price: f64,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_mark_price_history.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetMarkPriceHistoryResult {
+    /// List of mark price entries.
+    #[serde(rename = "mark_prices")]
+    pub mark_prices: Vec<MarkPriceEntry>,
+}
+
+/// Response for the get_mark_price_history endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetMarkPriceHistoryResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the mark price history.
+    #[serde(rename = "result")]
+    pub result: GetMarkPriceHistoryResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_mark_price_history endpoint.
+    ///
+    /// Retrieves historical mark prices for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_mark_price_history)
+    pub async fn get_mark_price_history(&self, params: GetMarkPriceHistoryRequest) -> DeribitResult<GetMarkPriceHistoryResponse> {
+        self.call_public("get_mark_price_history", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetMarkPriceHistoryRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            start_timestamp: 1680310000000,
+            end_timestamp: 1680310800000,
+            count: Some(2),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("1680310000000"));
+        assert!(json.contains("1680310800000"));
+        assert!(json.contains("count"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 22,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"mark_prices\": [
+                    {
+                        \"mark_price\": 65000.0,
+                        \"timestamp\": 1680310800000
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetMarkPriceHistoryResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 22);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.mark_prices.len(), 1);
+        let entry = &resp.result.mark_prices[0];
+        assert!((entry.mark_price - 65000.0).abs() < 1e-8);
+        assert_eq!(entry.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_order_book.rs
+++ b/venues/src/deribit/public/rest/get_order_book.rs
@@ -2,9 +2,8 @@
 //!
 //! Retrieves the current order book for a given instrument.
 
-use crate::deribit::RestResult;
-use crate::deribit::enums::{OrderDirection, OrderState, OrderType};
-use crate::deribit::public::rest::client::{EndpointType, RestClient};
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
 
 use reqwest::Method;
 use serde::{Deserialize, Serialize};

--- a/venues/src/deribit/public/rest/get_order_book.rs
+++ b/venues/src/deribit/public/rest/get_order_book.rs
@@ -1,0 +1,127 @@
+//! Implements the /public/get_order_book endpoint for Deribit.
+//!
+//! Retrieves the current order book for a given instrument.
+
+use crate::deribit::enums::{OrderType, OrderState, OrderDirection};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_order_book endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetOrderBookRequest {
+    /// Instrument name for which to retrieve the order book.
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: String,
+
+    /// Depth of the order book to return (optional, default: 20, max: 200).
+    #[serde(rename = "depth", skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u32>,
+}
+
+/// Represents a single order book entry (bid or ask).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrderBookEntry {
+    /// Price level.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount available at this price level.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+}
+
+/// The result object for get_order_book.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetOrderBookResult {
+    /// List of bid entries.
+    #[serde(rename = "bids")]
+    pub bids: Vec<OrderBookEntry>,
+
+    /// List of ask entries.
+    #[serde(rename = "asks")]
+    pub asks: Vec<OrderBookEntry>,
+
+    /// The best bid price.
+    #[serde(rename = "best_bid_price")]
+    pub best_bid_price: f64,
+
+    /// The best ask price.
+    #[serde(rename = "best_ask_price")]
+    pub best_ask_price: f64,
+
+    /// The timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_order_book endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetOrderBookResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the order book.
+    #[serde(rename = "result")]
+    pub result: GetOrderBookResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_order_book endpoint.
+    ///
+    /// Retrieves the current order book for a given instrument.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_order_book)
+    pub async fn get_order_book(&self, params: GetOrderBookRequest) -> DeribitResult<GetOrderBookResponse> {
+        self.call_public("get_order_book", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetOrderBookRequest {
+            instrument_name: "BTC-PERPETUAL".to_string(),
+            depth: Some(10),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("depth"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 23,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"bids\": [
+                    {\"price\": 64999.0, \"amount\": 0.5}
+                ],
+                \"asks\": [
+                    {\"price\": 65001.0, \"amount\": 0.4}
+                ],
+                \"best_bid_price\": 64999.0,
+                \"best_ask_price\": 65001.0,
+                \"timestamp\": 1680310800000
+            }
+        }"#;
+        let resp: GetOrderBookResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 23);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.bids.len(), 1);
+        assert_eq!(resp.result.asks.len(), 1);
+        assert!((resp.result.best_bid_price - 64999.0).abs() < 1e-8);
+        assert!((resp.result.best_ask_price - 65001.0).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_order_book.rs
+++ b/venues/src/deribit/public/rest/get_order_book.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves the current order book for a given instrument.
 
-use crate::deribit::enums::{OrderType, OrderState, OrderDirection};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::RestResult;
+use crate::deribit::enums::{OrderDirection, OrderState, OrderType};
+use crate::deribit::public::rest::client::{EndpointType, RestClient};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_order_book endpoint.
@@ -77,8 +79,14 @@ impl RestClient {
     /// Retrieves the current order book for a given instrument.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_order_book)
-    pub async fn get_order_book(&self, params: GetOrderBookRequest) -> DeribitResult<GetOrderBookResponse> {
-        self.call_public("get_order_book", &params).await
+    pub async fn get_order_book(&self, params: GetOrderBookRequest) -> RestResult<GetOrderBookResponse> {
+        self.send_request(
+            "get_order_book",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
+++ b/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
@@ -1,0 +1,126 @@
+//! Implements the /public/get_order_book_by_instrument_id endpoint for Deribit.
+//!
+//! Retrieves the current order book for a given instrument by its ID.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_order_book_by_instrument_id endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetOrderBookByInstrumentIdRequest {
+    /// Instrument ID for which to retrieve the order book.
+    #[serde(rename = "instrument_id")]
+    pub instrument_id: String,
+
+    /// Depth of the order book to return (optional, default: 20, max: 200).
+    #[serde(rename = "depth", skip_serializing_if = "Option::is_none")]
+    pub depth: Option<u32>,
+}
+
+/// Represents a single order book entry (bid or ask).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OrderBookEntry {
+    /// Price level.
+    #[serde(rename = "price")]
+    pub price: f64,
+
+    /// Amount available at this price level.
+    #[serde(rename = "amount")]
+    pub amount: f64,
+}
+
+/// The result object for get_order_book_by_instrument_id.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetOrderBookByInstrumentIdResult {
+    /// List of bid entries.
+    #[serde(rename = "bids")]
+    pub bids: Vec<OrderBookEntry>,
+
+    /// List of ask entries.
+    #[serde(rename = "asks")]
+    pub asks: Vec<OrderBookEntry>,
+
+    /// The best bid price.
+    #[serde(rename = "best_bid_price")]
+    pub best_bid_price: f64,
+
+    /// The best ask price.
+    #[serde(rename = "best_ask_price")]
+    pub best_ask_price: f64,
+
+    /// The timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_order_book_by_instrument_id endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetOrderBookByInstrumentIdResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the order book.
+    #[serde(rename = "result")]
+    pub result: GetOrderBookByInstrumentIdResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_order_book_by_instrument_id endpoint.
+    ///
+    /// Retrieves the current order book for a given instrument by its ID.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_order_book_by_instrument_id)
+    pub async fn get_order_book_by_instrument_id(&self, params: GetOrderBookByInstrumentIdRequest) -> DeribitResult<GetOrderBookByInstrumentIdResponse> {
+        self.call_public("get_order_book_by_instrument_id", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetOrderBookByInstrumentIdRequest {
+            instrument_id: "BTC-PERPETUAL-ID".to_string(),
+            depth: Some(10),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL-ID"));
+        assert!(json.contains("depth"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 24,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"bids\": [
+                    {\"price\": 64998.0, \"amount\": 0.6}
+                ],
+                \"asks\": [
+                    {\"price\": 65002.0, \"amount\": 0.3}
+                ],
+                \"best_bid_price\": 64998.0,
+                \"best_ask_price\": 65002.0,
+                \"timestamp\": 1680310800000
+            }
+        }"#;
+        let resp: GetOrderBookByInstrumentIdResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 24);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.bids.len(), 1);
+        assert_eq!(resp.result.asks.len(), 1);
+        assert!((resp.result.best_bid_price - 64998.0).abs() < 1e-8);
+        assert!((resp.result.best_ask_price - 65002.0).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
+++ b/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
@@ -2,8 +2,9 @@
 //!
 //! Retrieves the current order book for a given instrument by its ID.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_order_book_by_instrument_id endpoint.
@@ -76,8 +77,9 @@ impl RestClient {
     /// Retrieves the current order book for a given instrument by its ID.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_order_book_by_instrument_id)
-    pub async fn get_order_book_by_instrument_id(&self, params: GetOrderBookByInstrumentIdRequest) -> DeribitResult<GetOrderBookByInstrumentIdResponse> {
-        self.call_public("get_order_book_by_instrument_id", &params).await
+    pub async fn get_order_book_by_instrument_id(&self, params: GetOrderBookByInstrumentIdRequest) -> RestResult<GetOrderBookByInstrumentIdResponse> {
+        self.call_public("get_order_book_by_instrument_id", &params)
+            .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
+++ b/venues/src/deribit/public/rest/get_order_book_by_instrument_id.rs
@@ -3,8 +3,9 @@
 //! Retrieves the current order book for a given instrument by its ID.
 
 use super::RestClient;
-use crate::deribit::RestResult;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_order_book_by_instrument_id endpoint.
@@ -78,8 +79,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_order_book_by_instrument_id)
     pub async fn get_order_book_by_instrument_id(&self, params: GetOrderBookByInstrumentIdRequest) -> RestResult<GetOrderBookByInstrumentIdResponse> {
-        self.call_public("get_order_book_by_instrument_id", &params)
-            .await
+        self.send_request(
+            "get_order_book_by_instrument_id",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_rfqs.rs
+++ b/venues/src/deribit/public/rest/get_rfqs.rs
@@ -2,9 +2,10 @@
 //!
 //! Retrieves the list of current RFQs (Request For Quotes).
 
+use super::RestClient;
+use crate::deribit::EndpointType;
 use crate::deribit::RestResult;
 use crate::deribit::enums::ComboState;
-use crate::deribit::public::rest::client::{EndpointType, RestClient};
 
 use reqwest::Method;
 use serde::{Deserialize, Serialize};

--- a/venues/src/deribit/public/rest/get_rfqs.rs
+++ b/venues/src/deribit/public/rest/get_rfqs.rs
@@ -2,9 +2,11 @@
 //!
 //! Retrieves the list of current RFQs (Request For Quotes).
 
-use crate::deribit::enums::{ComboState};
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use crate::deribit::RestResult;
+use crate::deribit::enums::ComboState;
+use crate::deribit::public::rest::client::{EndpointType, RestClient};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_rfqs endpoint.
@@ -65,8 +67,14 @@ impl RestClient {
     /// Retrieves the list of current RFQs (Request For Quotes).
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_rfqs)
-    pub async fn get_rfqs(&self, params: GetRfqsRequest) -> DeribitResult<GetRfqsResponse> {
-        self.call_public("get_rfqs", &params).await
+    pub async fn get_rfqs(&self, params: GetRfqsRequest) -> RestResult<GetRfqsResponse> {
+        self.send_request(
+            "get_rfqs",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_rfqs.rs
+++ b/venues/src/deribit/public/rest/get_rfqs.rs
@@ -1,0 +1,114 @@
+//! Implements the /public/get_rfqs endpoint for Deribit.
+//!
+//! Retrieves the list of current RFQs (Request For Quotes).
+
+use crate::deribit::enums::{ComboState};
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_rfqs endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetRfqsRequest {
+    /// State of the RFQ to filter (optional).
+    #[serde(rename = "state", skip_serializing_if = "Option::is_none")]
+    pub state: Option<ComboState>,
+
+    /// Number of results to return (default: 10, max: 1000).
+    #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}
+
+/// Represents a single RFQ entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RfqEntry {
+    /// RFQ ID.
+    #[serde(rename = "rfq_id")]
+    pub rfq_id: String,
+
+    /// State of the RFQ.
+    #[serde(rename = "state")]
+    pub state: ComboState,
+
+    /// Timestamp in milliseconds since epoch.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// The result object for get_rfqs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetRfqsResult {
+    /// List of RFQ entries.
+    #[serde(rename = "rfqs")]
+    pub rfqs: Vec<RfqEntry>,
+}
+
+/// Response for the get_rfqs endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetRfqsResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the RFQs.
+    #[serde(rename = "result")]
+    pub result: GetRfqsResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_rfqs endpoint.
+    ///
+    /// Retrieves the list of current RFQs (Request For Quotes).
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_rfqs)
+    pub async fn get_rfqs(&self, params: GetRfqsRequest) -> DeribitResult<GetRfqsResponse> {
+        self.call_public("get_rfqs", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::ComboState;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetRfqsRequest {
+            state: Some(ComboState::Active),
+            count: Some(2),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("active"));
+        assert!(json.contains("count"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 25,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"rfqs\": [
+                    {
+                        \"rfq_id\": \"rfq-123\",
+                        \"state\": "active",
+                        \"timestamp\": 1680310800000
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetRfqsResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 25);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.rfqs.len(), 1);
+        let rfq = &resp.result.rfqs[0];
+        assert_eq!(rfq.rfq_id, "rfq-123");
+        assert_eq!(rfq.state, ComboState::Active);
+        assert_eq!(rfq.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/get_status.rs
+++ b/venues/src/deribit/public/rest/get_status.rs
@@ -172,7 +172,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::NonMatchingEngineGetStatus)
+            .check_limits(EndpointType::NonMatchingEngine)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_status.rs
+++ b/venues/src/deribit/public/rest/get_status.rs
@@ -2,10 +2,10 @@
 //!
 //! Method used to get information about locked currencies
 
-use serde::{Deserialize, Serialize};
-
 use super::client::RestClient;
 use crate::deribit::{EndpointType, RestResult};
+
+use serde::{Deserialize, Serialize};
 
 /// Request parameters for the public/status endpoint.
 ///
@@ -56,7 +56,7 @@ impl RestClient {
             "public/status",
             reqwest::Method::GET,
             Some(&params),
-            EndpointType::PublicGetStatus,
+            EndpointType::NonMatchingEngine,
         )
         .await
     }
@@ -172,7 +172,7 @@ mod tests {
         // Test that rate limiting works for this endpoint type
         let result = rest_client
             .rate_limiter
-            .check_limits(EndpointType::PublicGetStatus)
+            .check_limits(EndpointType::NonMatchingEngineGetStatus)
             .await;
         assert!(result.is_ok());
     }

--- a/venues/src/deribit/public/rest/get_supported_index_names.rs
+++ b/venues/src/deribit/public/rest/get_supported_index_names.rs
@@ -1,0 +1,76 @@
+//! Implements the /public/get_supported_index_names endpoint for Deribit.
+//!
+//! Retrieves the list of supported index names.
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_supported_index_names endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetSupportedIndexNamesRequest {}
+
+/// The result object for get_supported_index_names.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetSupportedIndexNamesResult {
+    /// List of supported index names.
+    #[serde(rename = "index_names")]
+    pub index_names: Vec<String>,
+}
+
+/// Response for the get_supported_index_names endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetSupportedIndexNamesResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the supported index names.
+    #[serde(rename = "result")]
+    pub result: GetSupportedIndexNamesResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_supported_index_names endpoint.
+    ///
+    /// Retrieves the list of supported index names.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_supported_index_names)
+    pub async fn get_supported_index_names(&self, params: GetSupportedIndexNamesRequest) -> DeribitResult<GetSupportedIndexNamesResponse> {
+        self.call_public("get_supported_index_names", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetSupportedIndexNamesRequest {};
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("{}"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 26,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"index_names\": ["btc_usd", "eth_usd"]
+            }
+        }"#;
+        let resp: GetSupportedIndexNamesResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 26);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.index_names.len(), 2);
+        assert_eq!(resp.result.index_names[0], "btc_usd");
+        assert_eq!(resp.result.index_names[1], "eth_usd");
+    }
+}

--- a/venues/src/deribit/public/rest/get_supported_index_names.rs
+++ b/venues/src/deribit/public/rest/get_supported_index_names.rs
@@ -2,8 +2,10 @@
 //!
 //! Retrieves the list of supported index names.
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_supported_index_names endpoint.
@@ -40,8 +42,14 @@ impl RestClient {
     /// Retrieves the list of supported index names.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_supported_index_names)
-    pub async fn get_supported_index_names(&self, params: GetSupportedIndexNamesRequest) -> DeribitResult<GetSupportedIndexNamesResponse> {
-        self.call_public("get_supported_index_names", &params).await
+    pub async fn get_supported_index_names(&self, params: GetSupportedIndexNamesRequest) -> RestResult<GetSupportedIndexNamesResponse> {
+        self.send_request(
+            "get_supported_index_names",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_trade_volumes.rs
+++ b/venues/src/deribit/public/rest/get_trade_volumes.rs
@@ -1,0 +1,102 @@
+//! Implements the /public/get_trade_volumes endpoint for Deribit.
+//!
+//! Retrieves the trade volumes for all supported currencies.
+
+use crate::deribit::enums::Currency;
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+
+/// Request parameters for the get_trade_volumes endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetTradeVolumesRequest {}
+
+/// Represents a single trade volume entry.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TradeVolumeEntry {
+    /// Currency for which the volume is reported.
+    #[serde(rename = "currency")]
+    pub currency: Currency,
+
+    /// Volume traded in the last 24 hours.
+    #[serde(rename = "volume_24h")]
+    pub volume_24h: f64,
+
+    /// Volume traded in the last 30 days.
+    #[serde(rename = "volume_30d")]
+    pub volume_30d: f64,
+}
+
+/// The result object for get_trade_volumes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetTradeVolumesResult {
+    /// List of trade volume entries.
+    #[serde(rename = "volumes")]
+    pub volumes: Vec<TradeVolumeEntry>,
+}
+
+/// Response for the get_trade_volumes endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GetTradeVolumesResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the trade volumes.
+    #[serde(rename = "result")]
+    pub result: GetTradeVolumesResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_trade_volumes endpoint.
+    ///
+    /// Retrieves the trade volumes for all supported currencies.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_trade_volumes)
+    pub async fn get_trade_volumes(&self, params: GetTradeVolumesRequest) -> DeribitResult<GetTradeVolumesResponse> {
+        self.call_public("get_trade_volumes", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deribit::enums::Currency;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetTradeVolumesRequest {};
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("{}"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{
+            \"id\": 27,
+            \"jsonrpc\": \"2.0\",
+            \"result\": {
+                \"volumes\": [
+                    {
+                        \"currency\": "BTC",
+                        \"volume_24h\": 12345.6,
+                        \"volume_30d\": 789012.3
+                    }
+                ]
+            }
+        }"#;
+        let resp: GetTradeVolumesResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 27);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.volumes.len(), 1);
+        let entry = &resp.result.volumes[0];
+        assert_eq!(entry.currency, Currency::BTC);
+        assert!((entry.volume_24h - 12345.6).abs() < 1e-8);
+        assert!((entry.volume_30d - 789012.3).abs() < 1e-8);
+    }
+}

--- a/venues/src/deribit/public/rest/get_trade_volumes.rs
+++ b/venues/src/deribit/public/rest/get_trade_volumes.rs
@@ -2,9 +2,10 @@
 //!
 //! Retrieves the trade volumes for all supported currencies.
 
+use super::RestClient;
+use crate::deribit::RestResult;
 use crate::deribit::enums::Currency;
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_trade_volumes endpoint.
@@ -57,7 +58,7 @@ impl RestClient {
     /// Retrieves the trade volumes for all supported currencies.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_trade_volumes)
-    pub async fn get_trade_volumes(&self, params: GetTradeVolumesRequest) -> DeribitResult<GetTradeVolumesResponse> {
+    pub async fn get_trade_volumes(&self, params: GetTradeVolumesRequest) -> RestResult<GetTradeVolumesResponse> {
         self.call_public("get_trade_volumes", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_trade_volumes.rs
+++ b/venues/src/deribit/public/rest/get_trade_volumes.rs
@@ -3,9 +3,10 @@
 //! Retrieves the trade volumes for all supported currencies.
 
 use super::RestClient;
-use crate::deribit::RestResult;
 use crate::deribit::enums::Currency;
+use crate::deribit::{EndpointType, RestResult};
 
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 /// Request parameters for the get_trade_volumes endpoint.
@@ -59,7 +60,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_trade_volumes)
     pub async fn get_trade_volumes(&self, params: GetTradeVolumesRequest) -> RestResult<GetTradeVolumesResponse> {
-        self.call_public("get_trade_volumes", &params).await
+        self.send_request(
+            "get_trade_volumes",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
@@ -5,7 +5,10 @@
 //! [Official API docs](https://docs.deribit.com/#public-get_tradingview_chart_data)
 
 use super::RestClient;
+use crate::deribit::EndpointType;
 use crate::deribit::Errors as DeribitError;
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use std::borrow::Cow;
@@ -83,9 +86,9 @@ impl RestClient {
     pub async fn get_tradingview_chart_data(&self, params: &GetTradingviewChartDataRequest) -> Result<GetTradingviewChartDataResponse, DeribitError> {
         self.send_request(
             "public/get_tradingview_chart_data",
-            reqwest::Method::GET,
+            Method::GET,
             Some(params),
-            crate::deribit::EndpointType::NonMatchingEngineGetTradingviewChartData,
+            EndpointType::NonMatchingEngine,
         )
         .await
     }

--- a/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
@@ -1,0 +1,128 @@
+//! Implements the /public/get_tradingview_chart_data endpoint for Deribit.
+//!
+//! Retrieves TradingView-compatible OHLCV chart data for a given instrument and time range.
+//!
+//! [Official API docs](https://docs.deribit.com/#public-get_tradingview_chart_data)
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::Errors as DeribitError;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// Request parameters for the get_tradingview_chart_data endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetTradingviewChartDataRequest {
+    /// Instrument name (e.g., "BTC-PERPETUAL").
+    #[serde(rename = "instrument_name")]
+    pub instrument_name: Cow<'static, str>,
+
+    /// Start timestamp (ms since epoch, inclusive).
+    #[serde(rename = "start_timestamp")]
+    pub start_timestamp: u64,
+
+    /// End timestamp (ms since epoch, inclusive).
+    #[serde(rename = "end_timestamp")]
+    pub end_timestamp: u64,
+
+    /// Desired resolution in seconds (e.g., 60 for 1m candles, 3600 for 1h candles).
+    #[serde(rename = "resolution")]
+    pub resolution: u32,
+}
+
+/// The result object for get_tradingview_chart_data.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct GetTradingviewChartDataResult {
+    /// List of open prices for each candle.
+    #[serde(rename = "o")]
+    pub open: Vec<f64>,
+
+    /// List of high prices for each candle.
+    #[serde(rename = "h")]
+    pub high: Vec<f64>,
+
+    /// List of low prices for each candle.
+    #[serde(rename = "l")]
+    pub low: Vec<f64>,
+
+    /// List of close prices for each candle.
+    #[serde(rename = "c")]
+    pub close: Vec<f64>,
+
+    /// List of volume values for each candle.
+    #[serde(rename = "v")]
+    pub volume: Vec<f64>,
+
+    /// List of timestamps (ms since epoch) for each candle.
+    #[serde(rename = "t")]
+    pub timestamps: Vec<u64>,
+}
+
+/// Response for the get_tradingview_chart_data endpoint.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct GetTradingviewChartDataResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the chart data.
+    #[serde(rename = "result")]
+    pub result: GetTradingviewChartDataResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_tradingview_chart_data endpoint.
+    ///
+    /// Retrieves TradingView-compatible OHLCV chart data for a given instrument and time range.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_tradingview_chart_data)
+    pub async fn get_tradingview_chart_data(
+        &self,
+        params: &GetTradingviewChartDataRequest,
+    ) -> Result<GetTradingviewChartDataResponse, DeribitError> {
+        self.send_request(
+            "public/get_tradingview_chart_data",
+            reqwest::Method::GET,
+            Some(params),
+            crate::deribit::EndpointType::PublicGetTradingviewChartData,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetTradingviewChartDataRequest {
+            instrument_name: Cow::Borrowed("BTC-PERPETUAL"),
+            start_timestamp: 1680310800000,
+            end_timestamp: 1680314400000,
+            resolution: 60,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("BTC-PERPETUAL"));
+        assert!(json.contains("1680310800000"));
+        assert!(json.contains("60"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{\n    \"id\": 42,\n    \"jsonrpc\": \"2.0\",\n    \"result\": {\n        \"o\": [65000.0, 65100.0],\n        \"h\": [65200.0, 65250.0],\n        \"l\": [64900.0, 65050.0],\n        \"c\": [65100.0, 65200.0],\n        \"v\": [10.5, 12.3],\n        \"t\": [1680310800000, 1680310860000]\n    }\n}"#;
+        let resp: GetTradingviewChartDataResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 42);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert_eq!(resp.result.open, vec![65000.0, 65100.0]);
+        assert_eq!(resp.result.high, vec![65200.0, 65250.0]);
+        assert_eq!(resp.result.low, vec![64900.0, 65050.0]);
+        assert_eq!(resp.result.close, vec![65100.0, 65200.0]);
+        assert_eq!(resp.result.volume, vec![10.5, 12.3]);
+        assert_eq!(resp.result.timestamps, vec![1680310800000, 1680310860000]);
+    }
+}

--- a/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
+++ b/venues/src/deribit/public/rest/get_tradingview_chart_data.rs
@@ -4,9 +4,10 @@
 //!
 //! [Official API docs](https://docs.deribit.com/#public-get_tradingview_chart_data)
 
-use crate::deribit::public::rest::client::RestClient;
+use super::RestClient;
 use crate::deribit::Errors as DeribitError;
 use serde::{Deserialize, Serialize};
+
 use std::borrow::Cow;
 
 /// Request parameters for the get_tradingview_chart_data endpoint.
@@ -79,15 +80,12 @@ impl RestClient {
     /// Retrieves TradingView-compatible OHLCV chart data for a given instrument and time range.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_tradingview_chart_data)
-    pub async fn get_tradingview_chart_data(
-        &self,
-        params: &GetTradingviewChartDataRequest,
-    ) -> Result<GetTradingviewChartDataResponse, DeribitError> {
+    pub async fn get_tradingview_chart_data(&self, params: &GetTradingviewChartDataRequest) -> Result<GetTradingviewChartDataResponse, DeribitError> {
         self.send_request(
             "public/get_tradingview_chart_data",
             reqwest::Method::GET,
             Some(params),
-            crate::deribit::EndpointType::PublicGetTradingviewChartData,
+            crate::deribit::EndpointType::NonMatchingEngineGetTradingviewChartData,
         )
         .await
     }

--- a/venues/src/deribit/public/rest/get_volatility_index_data.rs
+++ b/venues/src/deribit/public/rest/get_volatility_index_data.rs
@@ -4,9 +4,10 @@
 //!
 //! [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
 
-use crate::deribit::public::rest::client::RestClient;
-use crate::deribit::errors::Result as DeribitResult;
+use super::RestClient;
+use crate::deribit::RestResult;
 use serde::{Deserialize, Serialize};
+
 use std::borrow::Cow;
 
 /// Request parameters for the get_volatility_index_data endpoint.
@@ -51,10 +52,7 @@ impl RestClient {
     /// Retrieves volatility index data for a given index name.
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
-    pub async fn get_volatility_index_data(
-        &self,
-        params: GetVolatilityIndexDataRequest,
-    ) -> DeribitResult<GetVolatilityIndexDataResponse> {
+    pub async fn get_volatility_index_data(&self, params: GetVolatilityIndexDataRequest) -> RestResult<GetVolatilityIndexDataResponse> {
         self.call_public("get_volatility_index_data", &params).await
     }
 }

--- a/venues/src/deribit/public/rest/get_volatility_index_data.rs
+++ b/venues/src/deribit/public/rest/get_volatility_index_data.rs
@@ -5,7 +5,9 @@
 //! [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
 
 use super::RestClient;
-use crate::deribit::RestResult;
+use crate::deribit::{EndpointType, RestResult};
+
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use std::borrow::Cow;
@@ -53,7 +55,13 @@ impl RestClient {
     ///
     /// [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
     pub async fn get_volatility_index_data(&self, params: GetVolatilityIndexDataRequest) -> RestResult<GetVolatilityIndexDataResponse> {
-        self.call_public("get_volatility_index_data", &params).await
+        self.send_request(
+            "get_volatility_index_data",
+            Method::POST,
+            Some(&params),
+            EndpointType::NonMatchingEngine,
+        )
+        .await
     }
 }
 

--- a/venues/src/deribit/public/rest/get_volatility_index_data.rs
+++ b/venues/src/deribit/public/rest/get_volatility_index_data.rs
@@ -1,0 +1,85 @@
+//! Implements the /public/get_volatility_index_data endpoint for Deribit.
+//!
+//! Retrieves volatility index data for a given index name.
+//!
+//! [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
+
+use crate::deribit::public::rest::client::RestClient;
+use crate::deribit::errors::Result as DeribitResult;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// Request parameters for the get_volatility_index_data endpoint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GetVolatilityIndexDataRequest {
+    /// Index name (e.g., "btc_usd").
+    #[serde(rename = "index_name")]
+    pub index_name: Cow<'static, str>,
+}
+
+/// The result object for get_volatility_index_data.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct GetVolatilityIndexDataResult {
+    /// The current volatility index value.
+    #[serde(rename = "volatility_index")]
+    pub volatility_index: f64,
+
+    /// Timestamp in milliseconds since epoch for the volatility index value.
+    #[serde(rename = "timestamp")]
+    pub timestamp: u64,
+}
+
+/// Response for the get_volatility_index_data endpoint.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct GetVolatilityIndexDataResponse {
+    /// The id that was sent in the request.
+    #[serde(rename = "id")]
+    pub id: u64,
+
+    /// The JSON-RPC version (2.0).
+    #[serde(rename = "jsonrpc")]
+    pub jsonrpc: String,
+
+    /// The result object containing the volatility index data.
+    #[serde(rename = "result")]
+    pub result: GetVolatilityIndexDataResult,
+}
+
+impl RestClient {
+    /// Calls the /public/get_volatility_index_data endpoint.
+    ///
+    /// Retrieves volatility index data for a given index name.
+    ///
+    /// [Official API docs](https://docs.deribit.com/#public-get_volatility_index_data)
+    pub async fn get_volatility_index_data(
+        &self,
+        params: GetVolatilityIndexDataRequest,
+    ) -> DeribitResult<GetVolatilityIndexDataResponse> {
+        self.call_public("get_volatility_index_data", &params).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_request() {
+        let req = GetVolatilityIndexDataRequest {
+            index_name: Cow::Borrowed("btc_usd"),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("btc_usd"));
+    }
+
+    #[test]
+    fn test_deserialize_response() {
+        let data = r#"{\n    \"id\": 21,\n    \"jsonrpc\": \"2.0\",\n    \"result\": {\n        \"volatility_index\": 5.4321,\n        \"timestamp\": 1680310800000\n    }\n}"#;
+        let resp: GetVolatilityIndexDataResponse = serde_json::from_str(data).unwrap();
+        assert_eq!(resp.id, 21);
+        assert_eq!(resp.jsonrpc, "2.0");
+        assert!((resp.result.volatility_index - 5.4321).abs() < 1e-8);
+        assert_eq!(resp.result.timestamp, 1680310800000);
+    }
+}

--- a/venues/src/deribit/public/rest/mod.rs
+++ b/venues/src/deribit/public/rest/mod.rs
@@ -6,6 +6,38 @@ pub mod get_status;
 pub mod get_time;
 pub mod test;
 
+pub mod get_apr_history;
+pub mod get_book_summary_by_currency;
+pub mod get_book_summary_by_instrument;
+pub mod get_contract_size;
+pub mod get_currencies;
+pub mod get_delivery_prices;
+pub mod get_expirations;
+pub mod get_funding_chart_data;
+pub mod get_funding_rate_history;
+pub mod get_funding_rate_value;
+pub mod get_historical_volatility;
+pub mod get_index;
+pub mod get_index_price;
+pub mod get_index_price_names;
+pub mod get_instrument;
+pub mod get_instruments;
+pub mod get_last_settlements_by_currency;
+pub mod get_last_settlements_by_instrument;
+pub mod get_last_trades_by_currency;
+pub mod get_last_trades_by_currency_and_time;
+pub mod get_last_trades_by_instrument;
+pub mod get_last_trades_by_instrument_and_time;
+pub mod get_mark_price_history;
+pub mod get_order_book;
+pub mod get_order_book_by_instrument_id;
+pub mod get_rfqs;
+pub mod get_supported_index_names;
+pub mod get_trade_volumes;
+pub mod get_tradingview_chart_data;
+pub mod get_volatility_index_data;
+pub mod ticker;
+
 pub use client::RestClient;
 pub use get_combo_details::{GetComboDetailsRequest, GetComboDetailsResponse};
 pub use get_combo_ids::{GetComboIdsRequest, GetComboIdsResponse};
@@ -13,3 +45,8 @@ pub use get_combos::{ComboInfo, ComboLeg, GetCombosRequest, GetCombosResponse};
 pub use get_status::{GetStatusRequest, GetStatusResponse, GetStatusResult};
 pub use get_time::{GetTimeRequest, GetTimeResponse};
 pub use test::{TestRequest, TestResponse, TestResult};
+pub use get_tradingview_chart_data::{
+    GetTradingviewChartDataRequest,
+    GetTradingviewChartDataResponse,
+    GetTradingviewChartDataResult,
+};

--- a/venues/src/deribit/public/rest/ticker.rs
+++ b/venues/src/deribit/public/rest/ticker.rs
@@ -1,0 +1,4 @@
+// ...file header and imports...
+
+// This file will implement the /public/ticker endpoint for Deribit.
+// Request/response structs, enums, and RestClient method will be added next.


### PR DESCRIPTION
This pull request introduces several changes to the Deribit REST client implementation, focusing on adding new endpoints, updating endpoint types, and improving code organization. The most significant additions include support for new API endpoints to retrieve APR history, book summaries by currency and instrument, and updates to existing endpoints to align with the `NonMatchingEngine` endpoint type.

### Additions of new endpoints:

* [`venues/src/deribit/public/rest/get_apr_history.rs`](diffhunk://#diff-d1e6ee8271eb283a23fee5a77180548dc6481c092be9f5273f39f6bd30d28826R1-R124): Added support for the `/public/get_apr_history` endpoint to retrieve historical APR data for specified currencies (`USDE`, `STETH`). Includes request/response structures, implementation, and tests.
* [`venues/src/deribit/public/rest/get_book_summary_by_currency.rs`](diffhunk://#diff-9c5c43a17d0b1f6ad92af1b59cf24f09ce7def6293c2cfbba3e31b77b0b1d8ffR1-R209): Added support for the `/public/get_book_summary_by_currency` endpoint to retrieve summary information for all instruments of a currency, optionally filtered by kind. Includes request/response structures, implementation, and tests.
* [`venues/src/deribit/public/rest/get_book_summary_by_instrument.rs`](diffhunk://#diff-6d0c3aa205f2dbcf63c56d7bd995b2c9e2af33caec24de08d3e162db335092a2R1-R203): Added support for the `/public/get_book_summary_by_instrument` endpoint to retrieve summary information for a specific instrument. Includes request/response structures, implementation, and tests.

### Updates to endpoint types:

* Updated endpoint type from `PublicGetComboIds` to `NonMatchingEngine` across multiple files, including `venues/src/deribit/public/rest/client.rs` and `venues/src/deribit/public/rest/get_combo_ids.rs`. [[1]](diffhunk://#diff-ad5f17e2719105b99a1949fabb7a508dd670e94c876aca0e37caf7c027794076L165-R165) [[2]](diffhunk://#diff-81f529cb2f858d3df6cffb24992b8420bf16e03e3c8acb4fcbb9affd76be1ff5L56-R56) [[3]](diffhunk://#diff-81f529cb2f858d3df6cffb24992b8420bf16e03e3c8acb4fcbb9affd76be1ff5L160-R160)
* Updated endpoint type from `PublicGetComboDetails` to `NonMatchingEngine` in `venues/src/deribit/public/rest/get_combo_details.rs`. [[1]](diffhunk://#diff-e955aa3176144ab2ddfaafd96cc8679cde9576c70a79dba081fd11447906fcd8L50-R50) [[2]](diffhunk://#diff-e955aa3176144ab2ddfaafd96cc8679cde9576c70a79dba081fd11447906fcd8L162-R162)
* Updated endpoint type from `PublicGetCombos` to `NonMatchingEngine` in `venues/src/deribit/public/rest/get_combos.rs`.

### Code organization improvements:

* Reorganized imports in `venues/src/deribit/public/rest/get_combo_details.rs` and `venues/src/deribit/public/rest/get_combo_ids.rs` for consistency and readability. [[1]](diffhunk://#diff-e955aa3176144ab2ddfaafd96cc8679cde9576c70a79dba081fd11447906fcd8L5-R10) [[2]](diffhunk://#diff-81f529cb2f858d3df6cffb24992b8420bf16e03e3c8acb4fcbb9affd76be1ff5L6-R10)