### PR TITLE
Add simple web UI server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,73 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "backtrace"
@@ -1040,6 +1116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1134,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1414,6 +1497,21 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.2",
 ]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1862,6 +1960,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2292,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2618,6 +2770,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2638,6 +2791,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2681,10 +2835,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3000,6 +3158,24 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
+]
+
+[[package]]
+name = "webui"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "hex",
+ "hmac",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "rest",
     "venues/examples/binancecoinm",
     "venues/examples/binanceportfoliomargin",
-    "binance_macros"
+    "binance_macros",
+    "webui",
 ]
 
 [workspace.package]

--- a/webui/Cargo.toml
+++ b/webui/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "webui"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description.workspace = true
+
+[dependencies]
+axum = { version = "0.7", features = ["macros"] }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
+secrecy = "0.10"
+reqwest = { workspace = true, features = ["json"] }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+chrono = { workspace = true }
+[lints]
+workspace = true

--- a/webui/src/main.rs
+++ b/webui/src/main.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+
+use axum::{
+    Form, Router,
+    response::{Html, IntoResponse},
+    routing::{get, post},
+};
+use hmac::{Hmac, Mac};
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+use sha2::Sha256;
+use tokio::sync::Mutex;
+use tracing::info;
+
+#[derive(Clone, Default)]
+struct Credentials {
+    api_key: SecretString,
+    api_secret: SecretString,
+}
+
+#[derive(Default)]
+struct AppState {
+    creds: Mutex<Option<Credentials>>,
+}
+
+#[derive(Deserialize)]
+struct CredentialsForm {
+    api_key: String,
+    api_secret: String,
+}
+
+fn sign_query(query: &str, secret: &SecretString) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.expose_secret().as_bytes())
+        .expect("HMAC can take key of any size");
+    mac.update(query.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+async fn index() -> Html<&'static str> {
+    Html(
+        "<html><head><title>CCRXT Web UI</title></head><body>
+        <h1>Crypto Exchange Web UI</h1>
+        <form action='/set_keys' method='post'>
+            <label>API Key: <input name='api_key' type='text'/></label><br/>
+            <label>API Secret: <input name='api_secret' type='text'/></label><br/>
+            <button type='submit'>Save Keys</button>
+        </form>
+        <form action='/binance/server_time' method='post'>
+            <button type='submit'>Get Binance Server Time</button>
+        </form>
+        <form action='/binance/account' method='post'>
+            <button type='submit'>Get Binance Account Info</button>
+        </form>
+        </body></html>",
+    )
+}
+
+#[axum::debug_handler]
+async fn set_keys(
+    state: axum::extract::State<Arc<AppState>>,
+    Form(form): Form<CredentialsForm>,
+) -> impl IntoResponse {
+    let creds = Credentials {
+        api_key: SecretString::new(form.api_key.into()),
+        api_secret: SecretString::new(form.api_secret.into()),
+    };
+    *state.creds.lock().await = Some(creds);
+    info!("Stored API credentials");
+    axum::response::Redirect::to("/")
+}
+
+async fn binance_server_time() -> Html<String> {
+    let resp = match reqwest::get("https://fapi.binance.com/fapi/v1/time").await {
+        Ok(r) => r,
+        Err(e) => return Html(format!("<p>Error: {e}</p><p><a href='/'>Back</a></p>")),
+    };
+    let json: serde_json::Value = match resp.json().await {
+        Ok(j) => j,
+        Err(e) => return Html(format!("<p>Error: {e}</p><p><a href='/'>Back</a></p>")),
+    };
+    let pretty = match serde_json::to_string_pretty(&json) {
+        Ok(p) => p,
+        Err(e) => return Html(format!("<p>Error: {e}</p><p><a href='/'>Back</a></p>")),
+    };
+    Html(format!("<pre>{}</pre><p><a href='/'>Back</a></p>", pretty))
+}
+
+#[axum::debug_handler]
+async fn binance_account(state: axum::extract::State<Arc<AppState>>) -> Html<String> {
+    let creds_guard = state.creds.lock().await;
+    let Some(creds) = &*creds_guard else {
+        return Html("<p>No API keys set. <a href='/'>Back</a></p>".to_string());
+    };
+    use chrono::Utc;
+
+    let timestamp = Utc::now().timestamp_millis();
+    let recv_window = 5000u64;
+    let query = format!("timestamp={timestamp}&recvWindow={recv_window}");
+    let signature = sign_query(&query, &creds.api_secret);
+    let url = format!("https://fapi.binance.com/fapi/v2/account?{query}&signature={signature}");
+    let client = reqwest::Client::new();
+    let resp = match client
+        .get(&url)
+        .header("X-MBX-APIKEY", creds.api_key.expose_secret())
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => return Html(format!("<p>Error: {e}</p><p><a href='/'>Back</a></p>")),
+    };
+    let text = match resp.text().await {
+        Ok(t) => t,
+        Err(e) => return Html(format!("<p>Error: {e}</p><p><a href='/'>Back</a></p>")),
+    };
+    Html(format!("<pre>{}</pre><p><a href='/'>Back</a></p>", text))
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().with_env_filter("info").init();
+
+    let state = Arc::new(AppState::default());
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/set_keys", post(set_keys))
+        .route("/binance/server_time", post(binance_server_time))
+        .route("/binance/account", post(binance_account))
+        .with_state(state);
+
+    use tokio::net::TcpListener;
+
+    info!("Starting web UI on http://localhost:3000");
+    let listener = TcpListener::bind("0.0.0.0:3000")
+        .await
+        .expect("bind failed");
+    axum::serve(listener, app).await.expect("server failed");
+}


### PR DESCRIPTION
## Summary
- add new `webui` binary crate using Axum
- expose forms for API credentials and Binance requests
- wire up new crate in workspace

## Testing
- `cargo test -p webui --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685fcc6b92bc8320a71c3e0c3ff97f38