### PR TITLE
Refactor time handling and rate limiting for WASM compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,12 +469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,20 +564,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -801,12 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,10 +826,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -874,29 +846,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "governor"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbe789d04bf14543f03c4b60cd494148aa79438c8440ae7d81a7778147745c3"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.1",
- "hashbrown 0.15.2",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.1",
- "smallvec",
- "spinning_top",
- "web-time",
-]
 
 [[package]]
 name = "h2"
@@ -925,12 +874,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1641,12 +1584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,21 +1628,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -1801,15 +1723,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2241,15 +2154,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -2831,11 +2735,11 @@ dependencies = [
  "crossterm 0.29.0",
  "dotenv",
  "futures",
- "governor",
  "hex",
  "hmac",
  "nonzero_ext",
  "num_enum",
+ "once_cell",
  "parking_lot",
  "rand 0.9.1",
  "ratatui",
@@ -2860,6 +2764,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "web-time",
  "websockets",
 ]
 

--- a/docs/CREDENTIALS_MIGRATION_PLAN.md
+++ b/docs/CREDENTIALS_MIGRATION_PLAN.md
@@ -1,0 +1,292 @@
+# Credentials Struct Migration Plan
+
+## Overview
+This document outlines the comprehensive plan to migrate all venues from using individual `api_key` and `api_secret` parameters to dedicated `Credentials` structs for better security and consistency.
+
+## Current State
+
+### ✅ Already Migrated
+- **Bullish** (`venues/src/bullish/private/rest/credentials.rs`)
+- **KuCoin Spot** (`venues/src/kucoin/spot/private/rest/credentials.rs`)
+
+### ❌ Venues Requiring Migration
+Total: 19 private REST clients across 12 venues
+
+| Venue | Products | Paths |
+|-------|----------|--------|
+| Binance | 4 | `spot/`, `usdm/`, `coinm/`, `options/` |
+| GateIO | 5 | `spot/`, `perpetual/`, `delivery/`, `options/`, `unified/` |
+| BitMart | 2 | `spot/`, `contract/` |
+| OKX | 1 | `private/rest/` |
+| Deribit | 1 | `private/rest/` |
+| Coinbase Exchange | 1 | `private/rest/` |
+| Crypto.com | 1 | `private/rest/` |
+| Bybit | 1 | `private/rest/` |
+| BingX | 1 | `spot/private/rest/` |
+| Bitget | 1 | `spot/private/rest/` |
+| KuCoin Futures | 1 | `futures/private/rest/` |
+
+## Migration Strategy
+
+### Phase 1: Simple Venues (Single Private REST Client)
+Start with venues that have only one private REST client to establish the pattern:
+
+1. **OKX** (`okx/private/rest/`)
+2. **Deribit** (`deribit/private/rest/`)
+3. **Coinbase Exchange** (`coinbaseexchange/private/rest/`)
+4. **Crypto.com** (`cryptocom/private/rest/`)
+5. **Bybit** (`bybit/private/rest/`)
+
+### Phase 2: Multi-Product Venues
+Handle venues with multiple products that share credentials:
+
+1. **Binance** (4 products)
+   - Create shared `binance/shared/credentials.rs`
+   - Update all 4 products to use shared credentials
+   - Products: spot, usdm, coinm, options
+
+2. **GateIO** (5 products)
+   - Create shared `gateio/shared/credentials.rs`
+   - Update all 5 products to use shared credentials
+   - Products: spot, perpetual, delivery, options, unified
+
+3. **BitMart** (2 products)
+   - Evaluate if shared or separate credentials are needed
+   - Products: spot, contract
+
+### Phase 3: Remaining Venues
+1. **BingX** (`bingx/spot/private/rest/`)
+2. **Bitget** (`bitget/spot/private/rest/`)
+3. **KuCoin Futures** (`kucoin/futures/private/rest/`)
+   - Align with existing KuCoin Spot pattern
+
+## Implementation Pattern
+
+### Step 1: Create `credentials.rs`
+
+```rust
+//! [Venue Name] API credentials
+
+use rest::secrets::SecretString;
+
+/// Credentials for authenticating with [Venue] private REST API.
+///
+/// All fields are securely stored using SecretString.
+#[derive(Debug, Clone)]
+pub struct Credentials {
+    /// API key (required)
+    pub api_key: SecretString,
+
+    /// API secret (required)
+    pub api_secret: SecretString,
+
+    // Add venue-specific fields as needed
+    // Examples:
+    // /// API passphrase (required for KuCoin)
+    // pub api_passphrase: SecretString,
+}
+```
+
+### Step 2: Add Serialization (Optional but Recommended)
+
+For venues that need serialization, implement safe Serialize/Deserialize that masks secrets:
+
+```rust
+use serde::{Serialize, Deserialize, Serializer, Deserializer};
+use serde::ser::SerializeStruct;
+use serde::de::{MapAccess, Visitor};
+
+impl Serialize for Credentials {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut st = serializer.serialize_struct("Credentials", 2)?;
+        st.serialize_field("apiKey", &"***")?;
+        st.serialize_field("apiSecret", &"***")?;
+        st.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Credentials {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Implementation similar to Bullish pattern
+        // See venues/src/bullish/private/rest/credentials.rs for full example
+    }
+}
+```
+
+### Step 3: Update `client.rs`
+
+#### Before:
+```rust
+pub struct RestClient {
+    api_key: Box<dyn ExposableSecret>,
+    api_secret: Box<dyn ExposableSecret>,
+    // ... other fields
+}
+
+impl RestClient {
+    pub fn new(
+        api_key: Box<dyn ExposableSecret>,
+        api_secret: Box<dyn ExposableSecret>,
+        // ... other params
+    ) -> Self {
+        // ...
+    }
+}
+```
+
+#### After:
+```rust
+use super::credentials::Credentials;
+
+pub struct RestClient {
+    credentials: Credentials,
+    // ... other fields
+}
+
+impl RestClient {
+    pub fn new(
+        credentials: Credentials,
+        // ... other params
+    ) -> Self {
+        // ...
+    }
+}
+```
+
+### Step 4: Update Signing Methods
+
+Replace direct access to `api_key` and `api_secret`:
+
+#### Before:
+```rust
+let api_secret = self.api_secret.expose_secret();
+```
+
+#### After:
+```rust
+let api_secret = self.credentials.api_secret.expose_secret();
+```
+
+### Step 5: Update Module Exports
+
+In `mod.rs`, add:
+```rust
+pub use credentials::Credentials;
+```
+
+### Step 6: Update All Usage Points
+
+1. **Examples**: Update any examples that instantiate the client
+2. **Tests**: Update integration tests
+3. **Documentation**: Update README if applicable
+
+## Special Considerations
+
+### Multi-Product Venues (Binance, GateIO)
+
+For venues with multiple products sharing the same credentials:
+
+1. Create credentials in shared module:
+   - `binance/shared/credentials.rs`
+   - `gateio/shared/credentials.rs`
+
+2. Re-export from each product's private REST module:
+   ```rust
+   // In binance/spot/private/rest/mod.rs
+   pub use crate::binance::shared::credentials::Credentials;
+   ```
+
+### Venue-Specific Fields
+
+Some venues require additional fields:
+
+| Venue | Additional Fields |
+|-------|------------------|
+| KuCoin | `api_passphrase: SecretString` |
+| Coinbase | Might need JWT token field |
+| OKX | Might need passphrase |
+
+### Security Requirements
+
+1. **Never use plain `String`** for credentials - always use `SecretString`
+2. **Implement safe serialization** that masks secrets (return `"***"`)
+3. **Use `expose_secret()`** only when absolutely necessary (signing)
+4. **Never log credentials** even in debug mode
+
+## Testing Strategy
+
+### For Each Migration:
+
+1. **Compile Check**:
+   ```bash
+   cargo check --package venues
+   ```
+
+2. **Run Private Integration Tests**:
+   ```bash
+   RUN_PRIVATE_TESTS=true cargo test [venue_name]::
+   ```
+
+3. **Verify Examples** (if applicable):
+   ```bash
+   cargo run --example [venue_example]
+   ```
+
+4. **Security Audit**:
+   - Ensure no secrets in logs
+   - Verify serialization masks secrets
+   - Check that `SecretString` is used throughout
+
+## Migration Checklist
+
+For each venue migration:
+
+- [ ] Create `credentials.rs` file
+- [ ] Implement `Credentials` struct with `SecretString` fields
+- [ ] Add safe Serialize/Deserialize if needed
+- [ ] Update `client.rs` to use `Credentials`
+- [ ] Update all signing/auth methods
+- [ ] Export `Credentials` from module
+- [ ] Update examples (if any)
+- [ ] Update integration tests
+- [ ] Run tests with `RUN_PRIVATE_TESTS=true`
+- [ ] Verify no secrets are exposed in logs/serialization
+
+## Priority Order
+
+### High Priority (Simple, High-Impact)
+1. OKX
+2. Deribit
+3. Coinbase Exchange
+
+### Medium Priority (Multi-Product, Complex)
+4. Binance (4 products)
+5. GateIO (5 products)
+
+### Low Priority (Single Product, Less Used)
+6. Crypto.com
+7. Bybit
+8. BitMart
+9. BingX
+10. Bitget
+11. KuCoin Futures
+
+## Success Criteria
+
+- All 19 private REST clients use dedicated `Credentials` structs
+- No plain `String` types for secrets anywhere
+- Consistent pattern across all venues
+- All tests pass with proper authentication
+- No secrets exposed in logs or serialization
+
+## References
+
+- **Bullish Implementation**: `venues/src/bullish/private/rest/credentials.rs`
+- **KuCoin Implementation**: `venues/src/kucoin/spot/private/rest/credentials.rs`
+- **SecretString Documentation**: `rest::secrets::SecretString`

--- a/venues/Cargo.toml
+++ b/venues/Cargo.toml
@@ -3,6 +3,10 @@ name = "venues"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+wasm = ["web-time"]
+
 [dependencies]
 # Internal dependencies
 websockets = { path = "../websockets" }
@@ -35,7 +39,7 @@ clap.workspace = true
 aes-gcm = "0.10.3"
 base64 = "0.22.1"
 rand = "0.9.1"
-governor = "0.10.0"
+once_cell = "1.0"
 nonzero_ext = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
 url.workspace = true
@@ -44,6 +48,9 @@ secrecy = "0.10.3"
 urlencoding = "2.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"
+
+# WASM compatibility
+web-time = { version = "1.0", optional = true }
 
 [lints]
 workspace = true

--- a/venues/WASM_COMPATIBILITY_REPORT.md
+++ b/venues/WASM_COMPATIBILITY_REPORT.md
@@ -1,0 +1,152 @@
+# WASM Compatibility Report for Venues Crate
+
+## Executive Summary
+The venues crate currently has several blockers preventing WASM compilation. These issues stem primarily from native-only dependencies, time handling, cryptography libraries, and async runtime requirements.
+
+## Major Blockers
+
+### 1. Tokio Runtime with "full" Features
+**Location:** `venues/Cargo.toml:13`
+```toml
+tokio = { version = "1.0", features = ["full"] }
+```
+**Issue:** The "full" feature includes non-WASM compatible components:
+- File system operations
+- Process management
+- Signal handling
+- Native networking
+
+**Solution:** Use conditional compilation with reduced feature set for WASM or replace with wasm-bindgen-futures
+
+### 2. Native TLS in tokio-tungstenite
+**Location:** `venues/Cargo.toml:14`
+```toml
+tokio-tungstenite = { version = "0.27.0", features = ["native-tls"] }
+```
+**Issue:** native-tls uses system SSL libraries that don't exist in WASM environment
+
+**Solution:** 
+- For WASM: Use `rustls-tls-webpki-roots` feature or browser's WebSocket API
+- Implement conditional features in Cargo.toml
+
+### 3. Ring Cryptography Library
+**Location:** Used in Gate.io venue implementations
+- `venues/src/gateio/delivery/private/rest/client.rs:7`
+- `venues/src/gateio/spot/private/rest/client.rs:7`
+- `venues/src/gateio/options/private/rest/client.rs:7`
+- `venues/src/gateio/unified/private/rest/client.rs:7`
+- `venues/src/gateio/perpetual/private/rest/client.rs:7`
+
+**Issue:** Ring contains assembly code and C dependencies that don't compile to WASM
+
+**Solution:** Replace with pure Rust alternatives:
+- Use `hmac` and `sha2` crates directly (both support WASM)
+- These are already dependencies, just need to migrate the code
+
+### 4. std::time::Instant Usage
+**Locations:** Rate limiting implementations
+- `venues/src/bybit/rate_limit.rs` - Multiple uses of `Instant::now()`
+- `venues/src/deribit/rate_limit.rs` - Token bucket implementation
+- `venues/src/bitmart/contract/rate_limit.rs` - Duration handling
+
+**Issue:** `std::time::Instant` is not available in WASM (no monotonic clock)
+
+**Solution:** 
+- Use `web-time` crate which provides WASM-compatible `Instant`
+- Add conditional compilation: `#[cfg(target_arch = "wasm32")]`
+
+### 5. Governor Rate Limiting Crate
+**Location:** `venues/src/bitmart/contract/rate_limit.rs`
+```rust
+use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DefaultKeyedStateStore};
+```
+**Issue:** Governor internally uses `std::time::Instant`
+
+**Solution:** 
+- Create abstraction layer for rate limiting
+- Implement WASM-compatible rate limiter using browser's performance.now()
+- Use feature flags to switch implementations
+
+### 6. Terminal UI Dependencies
+**Location:** `venues/Cargo.toml:30-31`
+```toml
+ratatui = { workspace = true }
+crossterm = { workspace = true }
+```
+**Issue:** Terminal UI libraries require OS-level terminal access
+
+**Solution:** Make these optional dependencies with a feature flag
+
+### 7. Dotenv Dependency
+**Location:** `venues/Cargo.toml:34`
+```toml
+dotenv = "0.15"
+```
+**Issue:** File system access for .env files doesn't work in WASM
+
+**Solution:** 
+- Currently unused, can be removed
+- If needed, use browser/node environment variable APIs
+
+### 8. tokio::time::sleep Usage
+**Location:** `venues/src/deribit/rate_limit.rs:774`
+```rust
+tokio::time::sleep(Duration::from_millis(50)).await;
+```
+**Issue:** Tokio timers don't work in WASM
+
+**Solution:** Use wasm-bindgen futures and browser setTimeout
+
+## Recommended Implementation Strategy
+
+### Phase 1: Create Feature Flags
+```toml
+[features]
+default = ["native"]
+native = ["tokio/full", "tokio-tungstenite/native-tls", "terminal-ui"]
+wasm = ["tokio/sync", "tokio-tungstenite/rustls-tls-webpki-roots", "web-time", "getrandom/js"]
+terminal-ui = ["ratatui", "crossterm"]
+```
+
+### Phase 2: Abstract Time Handling
+Create a `time` module with conditional compilation:
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::{Duration, Instant};
+
+#[cfg(target_arch = "wasm32")]
+pub use web_time::{Duration, Instant};
+```
+
+### Phase 3: Replace Ring with Pure Rust
+Migrate Gate.io HMAC implementations from Ring to hmac/sha2 crates.
+
+### Phase 4: Abstract Rate Limiting
+Create trait-based rate limiting with separate implementations for native and WASM.
+
+### Phase 5: Conditional Async Runtime
+Use cfg attributes to switch between tokio (native) and wasm-bindgen-futures (WASM).
+
+## Testing Strategy
+1. Set up WASM build target: `rustup target add wasm32-unknown-unknown`
+2. Create test build script with `--target wasm32-unknown-unknown`
+3. Use wasm-pack for browser testing
+4. Set up CI to verify both native and WASM builds
+
+## Dependencies to Add for WASM Support
+```toml
+[dependencies]
+web-time = { version = "1.0", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+getrandom = { version = "0.2", features = ["js"], optional = true }
+```
+
+## Timeline Estimate
+- Phase 1-2: 1 day (feature flags and time abstraction)
+- Phase 3: 1 day (Ring replacement)
+- Phase 4: 2 days (rate limiting abstraction)
+- Phase 5: 2-3 days (async runtime abstraction)
+- Testing: 2 days
+
+**Total: ~1.5 weeks for full WASM compatibility**

--- a/venues/src/binance/coinm/private/rest/client.rs
+++ b/venues/src/binance/coinm/private/rest/client.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::time_compat::Instant;
 use std::{borrow::Cow, sync::Arc};
 
 use rest::HttpClient;

--- a/venues/src/binance/coinm/public/rest/client.rs
+++ b/venues/src/binance/coinm/public/rest/client.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::time_compat::Instant;
 
 use crate::binance::{
     coinm::{Errors, RestResponse, RestResult},

--- a/venues/src/binance/coinm/rate_limit.rs
+++ b/venues/src/binance/coinm/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::VecDeque,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/binance/options/private/rest/client.rs
+++ b/venues/src/binance/options/private/rest/client.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::time_compat::Instant;
 use std::{borrow::Cow, sync::Arc};
 
 use rest::HttpClient;

--- a/venues/src/binance/options/public/rest/client.rs
+++ b/venues/src/binance/options/public/rest/client.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use crate::time_compat::Instant;
 
 use crate::binance::{
     options::{Errors, RestResponse, RestResult},

--- a/venues/src/binance/options/rate_limit.rs
+++ b/venues/src/binance/options/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/binance/shared/rate_limiter.rs
+++ b/venues/src/binance/shared/rate_limiter.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/binance/spot/rate_limit.rs
+++ b/venues/src/binance/spot/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::VecDeque,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/binance/usdm/rate_limit.rs
+++ b/venues/src/binance/usdm/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::VecDeque,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/bingx/spot/rate_limit.rs
+++ b/venues/src/bingx/spot/rate_limit.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::HashMap,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/bitget/spot/private/rest/client.rs
+++ b/venues/src/bitget/spot/private/rest/client.rs
@@ -22,6 +22,8 @@
 
 use std::{borrow::Cow, sync::Arc};
 
+use crate::time_compat::Instant;
+
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use chrono::Utc;
 use hmac::{Hmac, Mac};
@@ -217,7 +219,7 @@ impl RestClient {
         }
 
         // Execute request
-        let start_time = std::time::Instant::now();
+        let start_time = Instant::now();
         let request = builder.build();
         let response = self
             .http_client

--- a/venues/src/bitget/spot/rate_limit.rs
+++ b/venues/src/bitget/spot/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::VecDeque,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::Deserialize;
 use tokio::sync::RwLock;

--- a/venues/src/bitmart/contract/mod.rs
+++ b/venues/src/bitmart/contract/mod.rs
@@ -1,2 +1,3 @@
 pub mod private;
 pub mod public;
+pub mod rate_limit;

--- a/venues/src/bitmart/contract/rate_limit.rs
+++ b/venues/src/bitmart/contract/rate_limit.rs
@@ -1,11 +1,10 @@
-use governor::middleware::NoOpMiddleware;
-use governor::state::keyed::KeyedRateLimiter;
-use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DefaultKeyedStateStore};
 use once_cell::sync::Lazy;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::sync::Arc;
+use crate::rate_limit_compat::{Quota, RateLimiter};
+use crate::time_compat::Duration;
 
 /// Enum for limit targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -30,63 +29,63 @@ pub static ENDPOINT_LIMITS: Lazy<Vec<EndpointRateLimit>> = Lazy::new(|| {
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/details"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/depth"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/open-interest"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(2).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/funding-rate"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/funding-rate-history"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/kline"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/markprice-kline"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/leverage-bracket"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/public/market-trade"),
             target: LimitTarget::Ip,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
@@ -94,203 +93,203 @@ pub static ENDPOINT_LIMITS: Lazy<Vec<EndpointRateLimit>> = Lazy::new(|| {
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/submit-order"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/cancel-order"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(40).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/cancel-orders"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(2).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/submit-plan-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/cancel-plan-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(40).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/submit-tp-sl-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/modify-plan-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/modify-preset-plan-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/modify-tp-sl-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/modify-limit-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/cancel-all-after"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(4).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/submit-trail-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/cancel-trail-order"),
             target: LimitTarget::Uid,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/set-position-mode"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(2).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/get-position-mode"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(2).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/get-open-orders"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(50).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/order"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(50).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/order-history"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(6).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/trades"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(6).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/transaction-history"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(6).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/assets-detail"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/position"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(6).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/position-v2"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(6).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/submit-leverage"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/v1/transfer-contract"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(1).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/v1/transfer-contract-list"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(1).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/current-plan-order"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(50).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/position-risk"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(24).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/contract/private/trade-fee-rate"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(2).unwrap()),
         },
@@ -298,42 +297,42 @@ pub static ENDPOINT_LIMITS: Lazy<Vec<EndpointRateLimit>> = Lazy::new(|| {
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/main/v1/sub-to-main"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(8).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/main/v1/main-to-sub"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(8).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/sub/v1/sub-to-main"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(8).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/main/v1/wallet"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(12).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/v1/transfer-history"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(8).unwrap()),
         },
         EndpointRateLimit {
             path: Cow::Borrowed("/account/contract/sub-account/main/v1/transfer-list"),
             target: LimitTarget::ApiKey,
-            quota: Quota::with_period(std::time::Duration::from_secs(2))
+            quota: Quota::with_period(Duration::from_secs(2))
                 .unwrap()
                 .allow_burst(NonZeroU32::new(8).unwrap()),
         },
@@ -346,7 +345,7 @@ pub struct BitmartRateLimiter {
     /// Keyed by (endpoint, target identifier)
     pub limiters: HashMap<
         (Cow<'static, str>, String),
-        Arc<KeyedRateLimiter<String, DefaultKeyedStateStore<String>, DefaultClock, NoOpMiddleware>>,
+        Arc<RateLimiter<String>>,
     >,
 }
 
@@ -363,7 +362,7 @@ impl BitmartRateLimiter {
         endpoint: &str,
         target: LimitTarget,
         id: &str,
-    ) -> Arc<KeyedRateLimiter<String, DefaultKeyedStateStore<String>, DefaultClock, NoOpMiddleware>>
+    ) -> Arc<RateLimiter<String>>
     {
         let key = (Cow::Owned(endpoint.to_string()), id.to_string());
         if let Some(limiter) = self.limiters.get(&key) {
@@ -374,7 +373,7 @@ impl BitmartRateLimiter {
                 .find(|e| e.path == endpoint && e.target == target)
                 .map(|e| e.quota)
                 .unwrap_or_else(|| Quota::per_second(NonZeroU32::new(1).unwrap()));
-            let limiter = Arc::new(KeyedRateLimiter::new(quota));
+            let limiter = Arc::new(RateLimiter::keyed(quota));
             self.limiters.insert(key, limiter.clone());
             limiter
         }

--- a/venues/src/bitmart/spot/rate_limit.rs
+++ b/venues/src/bitmart/spot/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::HashMap,
     fmt,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use tokio::sync::RwLock;
 

--- a/venues/src/bullish/rate_limit.rs
+++ b/venues/src/bullish/rate_limit.rs
@@ -3,8 +3,9 @@
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/bybit/rate_limit.rs
+++ b/venues/src/bybit/rate_limit.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/coinbaseexchange/rate_limit.rs
+++ b/venues/src/coinbaseexchange/rate_limit.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::HashMap,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/cryptocom/rate_limit.rs
+++ b/venues/src/cryptocom/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use tokio::sync::RwLock;
 

--- a/venues/src/deribit/rate_limit.rs
+++ b/venues/src/deribit/rate_limit.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/gateio/shared/rate_limit.rs
+++ b/venues/src/gateio/shared/rate_limit.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::HashMap,
     sync::Arc,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use tokio::sync::{Mutex, Semaphore};
 

--- a/venues/src/kucoin/spot/rate_limit.rs
+++ b/venues/src/kucoin/spot/rate_limit.rs
@@ -3,8 +3,9 @@
 
 use std::{
     collections::HashMap,
-    time::{Duration, Instant},
 };
+
+use crate::time_compat::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/venues/src/lib.rs
+++ b/venues/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod time_compat;
+pub mod rate_limit_compat;
+
 pub mod binance;
 pub mod bingx;
 pub mod bitget;

--- a/venues/src/okx/rate_limit.rs
+++ b/venues/src/okx/rate_limit.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use crate::time_compat::{Duration, Instant};
 
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/venues/src/rate_limit_compat.rs
+++ b/venues/src/rate_limit_compat.rs
@@ -1,0 +1,197 @@
+/// Rate limiting compatibility module for WASM and native platforms
+/// 
+/// This module provides a unified interface for rate limiting that works
+/// both in native environments (using governor) and WASM contexts.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use crate::time_compat::{Duration, Instant};
+
+/// A quota specification for rate limiting
+#[derive(Debug, Clone, Copy)]
+pub struct Quota {
+    /// Maximum number of requests allowed
+    pub max_burst: u32,
+    /// Time period for the quota
+    pub period: Duration,
+}
+
+impl Quota {
+    /// Create a quota with a specific period
+    pub fn with_period(period: Duration) -> Option<Self> {
+        Some(Self {
+            max_burst: 1,
+            period,
+        })
+    }
+
+    /// Set the burst size (max requests allowed)
+    pub fn allow_burst(mut self, burst: std::num::NonZeroU32) -> Self {
+        self.max_burst = burst.get();
+        self
+    }
+
+    /// Create a per-second quota
+    pub fn per_second(burst: std::num::NonZeroU32) -> Self {
+        Self {
+            max_burst: burst.get(),
+            period: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Token bucket for rate limiting
+#[derive(Debug, Clone)]
+struct TokenBucket {
+    /// Maximum tokens (burst size)
+    max_tokens: u32,
+    /// Current tokens available
+    tokens: f64,
+    /// Last refill time
+    last_refill: Instant,
+    /// Refill rate (tokens per second)
+    refill_rate: f64,
+}
+
+impl TokenBucket {
+    fn new(quota: Quota) -> Self {
+        let refill_rate = quota.max_burst as f64 / quota.period.as_secs_f64();
+        Self {
+            max_tokens: quota.max_burst,
+            tokens: quota.max_burst as f64,
+            last_refill: Instant::now(),
+            refill_rate,
+        }
+    }
+
+    fn try_consume(&mut self, tokens: u32) -> bool {
+        self.refill();
+        
+        if self.tokens >= tokens as f64 {
+            self.tokens -= tokens as f64;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.max_tokens as f64);
+        self.last_refill = now;
+    }
+}
+
+/// Rate limiter implementation that works in both native and WASM
+#[derive(Debug)]
+pub struct RateLimiter<K> {
+    buckets: Arc<RwLock<HashMap<K, TokenBucket>>>,
+    quota: Quota,
+}
+
+impl<K: Eq + std::hash::Hash + Clone> RateLimiter<K> {
+    /// Create a new keyed rate limiter
+    pub fn keyed(quota: Quota) -> Self {
+        Self {
+            buckets: Arc::new(RwLock::new(HashMap::new())),
+            quota,
+        }
+    }
+
+    /// Check if a key can proceed (consumes one token)
+    pub async fn check_key(&self, key: &K) -> Result<(), ()> {
+        self.check_key_n(key, 1).await
+    }
+
+    /// Check if a key can proceed (consumes n tokens)
+    pub async fn check_key_n(&self, key: &K, tokens: u32) -> Result<(), ()> {
+        let mut buckets = self.buckets.write().await;
+        
+        let bucket = buckets.entry(key.clone())
+            .or_insert_with(|| TokenBucket::new(self.quota));
+        
+        if bucket.try_consume(tokens) {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Clean up old entries (optional, for memory management)
+    pub async fn cleanup_stale_entries(&self, older_than: Duration) {
+        let mut buckets = self.buckets.write().await;
+        let now = Instant::now();
+        
+        buckets.retain(|_, bucket| {
+            now.duration_since(bucket.last_refill) < older_than
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    #[tokio::test]
+    async fn test_rate_limiter_basic() {
+        let quota = Quota::with_period(Duration::from_secs(1))
+            .unwrap()
+            .allow_burst(NonZeroU32::new(2).unwrap());
+        
+        let limiter = RateLimiter::<String>::keyed(quota);
+        let key = "test_key".to_string();
+        
+        // First two requests should succeed
+        assert!(limiter.check_key(&key).await.is_ok());
+        assert!(limiter.check_key(&key).await.is_ok());
+        
+        // Third request should fail (exceeded burst)
+        assert!(limiter.check_key(&key).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_multiple_keys() {
+        let quota = Quota::with_period(Duration::from_secs(1))
+            .unwrap()
+            .allow_burst(NonZeroU32::new(1).unwrap());
+        
+        let limiter = RateLimiter::<String>::keyed(quota);
+        let key1 = "key1".to_string();
+        let key2 = "key2".to_string();
+        
+        // Each key should have its own quota
+        assert!(limiter.check_key(&key1).await.is_ok());
+        assert!(limiter.check_key(&key2).await.is_ok());
+        
+        // Both keys should be rate limited after one use
+        assert!(limiter.check_key(&key1).await.is_err());
+        assert!(limiter.check_key(&key2).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_refill() {
+        let quota = Quota::with_period(Duration::from_millis(100))
+            .unwrap()
+            .allow_burst(NonZeroU32::new(1).unwrap());
+        
+        let limiter = RateLimiter::<String>::keyed(quota);
+        let key = "test_key".to_string();
+        
+        // First request should succeed
+        assert!(limiter.check_key(&key).await.is_ok());
+        
+        // Second request should fail immediately
+        assert!(limiter.check_key(&key).await.is_err());
+        
+        // Wait for refill
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        
+        // Should succeed after refill
+        assert!(limiter.check_key(&key).await.is_ok());
+    }
+}
+

--- a/venues/src/time_compat.rs
+++ b/venues/src/time_compat.rs
@@ -1,0 +1,10 @@
+/// Time compatibility module for WASM and native platforms
+/// 
+/// This module provides a unified interface for time operations that works
+/// both in native environments and WASM (WebAssembly) contexts.
+
+#[cfg(not(feature = "wasm"))]
+pub use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+#[cfg(feature = "wasm")]
+pub use web_time::{Duration, Instant, SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
- Introduced `time_compat` module to unify time operations for native and WASM environments.
- Updated various rate limit implementations across venues to use `time_compat` for duration and instant handling.
- Created `rate_limit_compat` module to provide a unified interface for rate limiting that works in both native and WASM contexts.
- Replaced governor rate limiting with a custom implementation that is compatible with WASM.
- Added a comprehensive migration plan for transitioning to `Credentials` structs for API keys and secrets across multiple venues.
- Documented the WASM compatibility report outlining major blockers and recommended implementation strategies.